### PR TITLE
ASM-4913 fix ASM::WsMan.reboot from gem refactor

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -101,13 +101,11 @@ module ASM
     def self.reboot(endpoint, logger = nil)
       # Create the reboot job
       logger.debug("Rebooting server #{endpoint[:host]}") if logger
-      input_file = File.join(Pathname.new(__FILE__).parent, 'reboot.xml')
       instanceid = invoke(endpoint,
       'CreateRebootJob',
       'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate',
       :selector =>'//wsman:Selector Name="InstanceID"',
       :props => { 'RebootJobType' => '1' },
-      :input_file => input_file,
       :logger => logger)
 
       # Execute job


### PR DESCRIPTION
ASM::WsMan.reboot was moved into dell-asm-util, but included a
static file reboot.xml as part of its arguments. The reboot.xml
was not moved into dell-asm-util causing that function to
fail. The reboot.xml file was not really needed since the
RebootJobType parameter it provided was already included as a
wsman property, so this fix just removed its use.