### PR TITLE
remove ipRange from networkObjects in network_configuration

### DIFF
--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -146,6 +146,14 @@ describe ASM::NetworkConfiguration do
       expect(net_config.to_hash.keys).not_to include("cards")
     end
 
+    it "should not include ipRanges in networkObjects" do
+      net_config.get_all_partitions.each do |partition|
+        if partition.static
+          expect(partition.staticNetworkConfiguration.ipRange).to be_nil
+        end
+      end
+    end
+
     it 'should set interface, partition info on partitions' do
       net_config.add_partition_info!
       partition_index = 0


### PR DESCRIPTION
The ipRange field contains a list of ip ranges associated with the
given network. It is sometimes passed in different orders, which can
cause networkObjects that are ostensibly same (the same network id and
same static IP if it is a static network) to appear different. That
causes difficulty when doing things like trying to determine the set
of networks that are being used on a port.