### PR TITLE
ASM-4853 Partial support for new UI network config model

### DIFF
--- a/spec/fixtures/network_configuration/blade_fc.json
+++ b/spec/fixtures/network_configuration/blade_fc.json
@@ -1,0 +1,291 @@
+{
+  "id": "6036C6BD-842D-45FB-8297-B7A58C4C39EF",
+  "name": "Interface",
+  "redundancy": false,
+  "enabled": true,
+  "fabrictype": "fc",
+  "partitioned": false,
+  "nictype": "2x10Gb",
+  "interfaces": [
+    {
+      "id": "4D02B5FD-CCDB-45B1-84EA-325D4A77876D",
+      "name": "Port 1",
+      "partitioned": false,
+      "partitions": [
+        {
+          "id": "AEBC7F8E-4878-446C-9294-B96B7EAA7302",
+          "name": "1",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "774C882E-183D-4DE8-B841-8826213715C8",
+          "name": "2",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "09708B88-36F6-4EAC-AA00-5B656F29DA35",
+          "name": "3",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "779F3843-C86F-4788-8A50-A72D75226BA4",
+          "name": "4",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        }
+      ],
+      "enabled": false,
+      "redundancy": false,
+      "nictype": null
+    },
+    {
+      "id": "4C335284-2E31-48D0-BC2D-E8720F964A22",
+      "name": "Port 2",
+      "partitioned": false,
+      "partitions": [
+        {
+          "id": "4765A217-C8F7-454D-B908-BBA567B16BBA",
+          "name": "1",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "31A67866-7568-4716-94F1-C2C5222847FB",
+          "name": "2",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "C7CC19A0-1F77-4F94-AD84-1404FCB70922",
+          "name": "3",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "5F825600-E149-40F6-ACCC-B8677BCF8218",
+          "name": "4",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        }
+      ],
+      "enabled": false,
+      "redundancy": false,
+      "nictype": null
+    },
+    {
+      "id": "69FDE361-4CCD-4CCE-8121-439B4489271D",
+      "name": "Port 3",
+      "partitioned": false,
+      "partitions": [
+        {
+          "id": "24FBC3B1-556D-4AA6-8AC6-467C7F7F83AF",
+          "name": "1",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "5A057150-3199-4B17-8A1C-E552B126BE20",
+          "name": "2",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "BF760E77-F0F5-4B02-92EA-CB80BE267EF9",
+          "name": "3",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "69689361-EEBC-4590-B7ED-9EAFBA064510",
+          "name": "4",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        }
+      ],
+      "enabled": false,
+      "redundancy": false,
+      "nictype": null
+    },
+    {
+      "id": "1640C813-297B-4963-B4F2-14B04A554BEF",
+      "name": "Port 4",
+      "partitioned": false,
+      "partitions": [
+        {
+          "id": "0E44C79A-D3B1-4CF4-BCA4-349D7C025A2F",
+          "name": "1",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "E52A2853-08C8-4808-BB61-7324F2FCE3E4",
+          "name": "2",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "45D7D625-BE93-4B04-B93E-318CC68F9D24",
+          "name": "3",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        },
+        {
+          "id": "A3D31B58-016C-4CC4-BA91-CED4047B96C4",
+          "name": "4",
+          "networks": [
+
+          ],
+          "networkObjects": null,
+          "minimum": 0,
+          "maximum": 100,
+          "lanMacAddress": null,
+          "iscsiMacAddress": null,
+          "iscsiIQN": null,
+          "wwnn": null,
+          "wwpn": null
+        }
+      ],
+      "enabled": false,
+      "redundancy": false,
+      "nictype": null
+    }
+  ]
+}

--- a/spec/fixtures/network_configuration/blade_partitioned.json
+++ b/spec/fixtures/network_configuration/blade_partitioned.json
@@ -1,31 +1,36 @@
 {
-  "id": "5398b088-1a9a-4bb7-916c-1a43296c9255",
-  "servertype": "blade",
+  "id": "1245AB22-25A7-422C-AA7C-B3CB2FCCEA06",
+  "servertype": null,
   "fabrics": [
+
+  ],
+  "interfaces": [
     {
-      "id": "d0bb37ab-36f1-4f70-94e2-dde053d7709c",
-      "name": "Fabric A",
+      "id": "FDEDE934-5684-42A0-9F2D-C7DE1058B5DE",
+      "name": "Interface",
       "redundancy": true,
       "enabled": true,
-      "nictype": "2",
+      "fabrictype": "ethernet",
+      "partitioned": true,
+      "nictype": "2x10Gb",
       "interfaces": [
         {
-          "id": "1082ef26-d8a0-46f5-a96d-6dc6b06dfd12",
+          "id": "1CDDF7A8-CAC1-41C2-92E6-8E88F0917278",
           "name": "Port 1",
           "partitioned": true,
           "partitions": [
             {
-              "id": "0e3768ac-f25e-404b-9072-7d6a4002bec6",
+              "id": "1F7F2D9F-FF77-4BAB-BAD6-B3DA77B05FF3",
               "name": "1",
               "networks": [
-                "ff80808146056aa20146057c08e503a1",
-                "ff80808146056aa2014605840b3303e0"
+                "ff808081508c08e301508c7e1ebf065e",
+                "ff808081508c08e301508c60861e0643"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146057c08e503a1",
+                  "id": "ff808081508c08e301508c7e1ebf065e",
                   "name": "Hypervisor Management",
-                  "description": null,
+                  "description": "",
                   "type": "HYPERVISOR_MANAGEMENT",
                   "vlanId": 28,
                   "static": true,
@@ -34,23 +39,23 @@
                     "subnet": "255.255.0.0",
                     "primaryDns": "172.20.0.8",
                     "secondaryDns": null,
-                    "dnsSuffix": "aidev.net",
+                    "dnsSuffix": null,
                     "ipRange": [
                       {
-                        "Id": "ff80808146056aa20146057c08e603a2",
-                        "StartingIp": "172.28.12.115",
-                        "EndingIp": "172.28.12.135"
+                        "Id": "ff808081508c08e301508c7e1ebf065f",
+                        "StartingIp": "172.28.113.50",
+                        "EndingIp": "172.28.113.100"
                       }
                     ],
-                    "ipAddress": "172.28.12.118"
+                    "ipAddress": "172.28.113.50"
                   }
                 },
                 {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
+                  "id": "ff808081508c08e301508c60861e0643",
+                  "name": "PXE",
                   "description": "",
                   "type": "PXE",
-                  "vlanId": 20,
+                  "vlanId": 18,
                   "static": false,
                   "staticNetworkConfiguration": null
                 }
@@ -64,15 +69,15 @@
               "wwpn": null
             },
             {
-              "id": "f9a6eb30-a78a-4501-b762-2a75c08d1489",
+              "id": "8888DD1A-C6C0-4235-BAE3-AE7C2B429263",
               "name": "2",
               "networks": [
-                "ff80808146056aa20146138f3ded0497"
+                "ff808081508c08e301508c7f1d7f0693"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146138f3ded0497",
-                  "name": "vMotion 2",
+                  "id": "ff808081508c08e301508c7f1d7f0693",
+                  "name": "vMotion",
                   "description": "",
                   "type": "HYPERVISOR_MIGRATION",
                   "vlanId": 23,
@@ -85,12 +90,12 @@
                     "dnsSuffix": null,
                     "ipRange": [
                       {
-                        "Id": "ff80808146056aa20146138f3dee0498",
-                        "StartingIp": "172.23.12.115",
-                        "EndingIp": "172.23.12.145"
+                        "Id": "ff808081508c08e301508c7f1d7f0694",
+                        "StartingIp": "172.23.113.50",
+                        "EndingIp": "172.23.113.100"
                       }
                     ],
-                    "ipAddress": "172.23.12.115"
+                    "ipAddress": "172.23.113.50"
                   }
                 }
               ],
@@ -103,32 +108,32 @@
               "wwpn": null
             },
             {
-              "id": "f5f38868-45a5-4473-97a5-6886cb71d737",
+              "id": "FC06970A-107F-4372-AF70-18BC6814BDC2",
               "name": "3",
               "networks": [
-                "ff80808146056aa20146057c0bf003d1"
+                "ff808081508c08e301508c7f92b106c8"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146057c0bf003d1",
+                  "id": "ff808081508c08e301508c7f92b106c8",
                   "name": "Workload",
-                  "description": null,
+                  "description": "",
                   "type": "PRIVATE_LAN",
-                  "vlanId": 27,
+                  "vlanId": 20,
                   "static": false,
                   "staticNetworkConfiguration": null
                 }
               ],
               "minimum": 0,
               "maximum": 100,
-              "lanMacAddress": "00:0E:AA:CE:00:11",
+              "lanMacAddress": "00:0E:AA:F9:00:01",
               "iscsiMacAddress": null,
               "iscsiIQN": null,
               "wwnn": null,
               "wwpn": null
             },
             {
-              "id": "9e7c7aca-a3aa-4b87-a4d4-4d41f034d0b7",
+              "id": "75E82F42-8A59-4A5E-A1F7-D39A9F681A04",
               "name": "4",
               "networks": [
                 "ff80808146056aa20146057c0aad03b9"
@@ -137,24 +142,24 @@
                 {
                   "id": "ff80808146056aa20146057c0aad03b9",
                   "name": "iSCSI",
-                  "description": null,
+                  "description": "",
                   "type": "STORAGE_ISCSI_SAN",
                   "vlanId": 16,
                   "static": true,
-                  "staticNetworkConfiguration": {
-                    "gateway": "172.16.0.1",
-                    "subnet": "255.255.0.0",
-                    "primaryDns": "172.20.0.8",
-                    "secondaryDns": null,
-                    "dnsSuffix": "aidev.net",
-                    "ipRange": [
+                  "staticNetworkConfiguration":{
+                    "gateway":"172.16.0.1",
+                    "subnet":"255.255.0.0",
+                    "primaryDns":"172.20.0.8",
+                    "secondaryDns":null,
+                    "dnsSuffix":"aidev.net",
+                    "ipRange":[
                       {
-                        "Id": "ff80808146056aa20146057c0aae03ba",
-                        "StartingIp": "172.16.12.115",
-                        "EndingIp": "172.16.12.135"
+                        "Id":"ff80808146056aa20146057c0aae03ba",
+                        "StartingIp":"172.16.12.115",
+                        "EndingIp":"172.16.12.135"
                       }
                     ],
-                    "ipAddress": "172.16.12.120"
+                    "ipAddress":"172.16.12.121"
                   }
                 },
                 {
@@ -183,36 +188,34 @@
               ],
               "minimum": 0,
               "maximum": 100,
-              "lanMacAddress": "00:0E:AA:CE:00:15",
-              "iscsiMacAddress": "00:0E:AA:CE:00:12",
-              "iscsiIQN": "iqn.asm:software-asm-01-0000000000:0000000008",
+              "lanMacAddress": null,
+              "iscsiMacAddress": null,
+              "iscsiIQN": null,
               "wwnn": null,
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "f26cdd75-1414-44c1-8751-6cf878f7e80f",
+          "id": "41909A92-DDE3-4A60-8A7A-B420FD3F90E6",
           "name": "Port 2",
           "partitioned": true,
           "partitions": [
             {
-              "id": "0e3768ac-f25e-404b-9072-7d6a4002bec6",
+              "id": "1F7F2D9F-FF77-4BAB-BAD6-B3DA77B05FF3",
               "name": "1",
               "networks": [
-                "ff80808146056aa20146057c08e503a1",
-                "ff80808146056aa2014605840b3303e0"
+                "ff808081508c08e301508c7e1ebf065e",
+                "ff808081508c08e301508c60861e0643"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146057c08e503a1",
+                  "id": "ff808081508c08e301508c7e1ebf065e",
                   "name": "Hypervisor Management",
-                  "description": null,
+                  "description": "",
                   "type": "HYPERVISOR_MANAGEMENT",
                   "vlanId": 28,
                   "static": true,
@@ -221,23 +224,23 @@
                     "subnet": "255.255.0.0",
                     "primaryDns": "172.20.0.8",
                     "secondaryDns": null,
-                    "dnsSuffix": "aidev.net",
+                    "dnsSuffix": null,
                     "ipRange": [
                       {
-                        "Id": "ff80808146056aa20146057c08e603a2",
-                        "StartingIp": "172.28.12.115",
-                        "EndingIp": "172.28.12.135"
+                        "Id": "ff808081508c08e301508c7e1ebf065f",
+                        "StartingIp": "172.28.113.50",
+                        "EndingIp": "172.28.113.100"
                       }
                     ],
-                    "ipAddress": "172.28.12.118"
+                    "ipAddress": "172.28.113.50"
                   }
                 },
                 {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
+                  "id": "ff808081508c08e301508c60861e0643",
+                  "name": "PXE",
                   "description": "",
                   "type": "PXE",
-                  "vlanId": 20,
+                  "vlanId": 18,
                   "static": false,
                   "staticNetworkConfiguration": null
                 }
@@ -251,15 +254,15 @@
               "wwpn": null
             },
             {
-              "id": "f9a6eb30-a78a-4501-b762-2a75c08d1489",
+              "id": "8888DD1A-C6C0-4235-BAE3-AE7C2B429263",
               "name": "2",
               "networks": [
-                "ff80808146056aa20146138f3ded0497"
+                "ff808081508c08e301508c7f1d7f0693"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146138f3ded0497",
-                  "name": "vMotion 2",
+                  "id": "ff808081508c08e301508c7f1d7f0693",
+                  "name": "vMotion",
                   "description": "",
                   "type": "HYPERVISOR_MIGRATION",
                   "vlanId": 23,
@@ -272,12 +275,12 @@
                     "dnsSuffix": null,
                     "ipRange": [
                       {
-                        "Id": "ff80808146056aa20146138f3dee0498",
-                        "StartingIp": "172.23.12.115",
-                        "EndingIp": "172.23.12.145"
+                        "Id": "ff808081508c08e301508c7f1d7f0694",
+                        "StartingIp": "172.23.113.50",
+                        "EndingIp": "172.23.113.100"
                       }
                     ],
-                    "ipAddress": "172.23.12.115"
+                    "ipAddress": "172.23.113.50"
                   }
                 }
               ],
@@ -290,32 +293,32 @@
               "wwpn": null
             },
             {
-              "id": "f5f38868-45a5-4473-97a5-6886cb71d737",
+              "id": "FC06970A-107F-4372-AF70-18BC6814BDC2",
               "name": "3",
               "networks": [
-                "ff80808146056aa20146057c0bf003d1"
+                "ff808081508c08e301508c7f92b106c8"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa20146057c0bf003d1",
+                  "id": "ff808081508c08e301508c7f92b106c8",
                   "name": "Workload",
-                  "description": null,
+                  "description": "",
                   "type": "PRIVATE_LAN",
-                  "vlanId": 27,
+                  "vlanId": 20,
                   "static": false,
                   "staticNetworkConfiguration": null
                 }
               ],
               "minimum": 0,
               "maximum": 100,
-              "lanMacAddress": "00:0E:AA:CE:00:16",
+              "lanMacAddress": "00:0E:AA:F9:00:02",
               "iscsiMacAddress": null,
               "iscsiIQN": null,
               "wwnn": null,
               "wwpn": null
             },
             {
-              "id": "9e7c7aca-a3aa-4b87-a4d4-4d41f034d0b7",
+              "id": "75E82F42-8A59-4A5E-A1F7-D39A9F681A04",
               "name": "4",
               "networks": [
                 "ff80808146056aa20146057c0aad03b9"
@@ -370,31 +373,29 @@
               ],
               "minimum": 0,
               "maximum": 100,
-              "lanMacAddress": "00:0E:AA:CE:00:1A",
-              "iscsiMacAddress": "00:0E:AA:CE:00:17",
-              "iscsiIQN": "iqn.asm:software-asm-01-0000000000:000000000A",
+              "lanMacAddress": null,
+              "iscsiMacAddress": null,
+              "iscsiIQN": null,
               "wwnn": null,
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "a8469c64-cfa2-4fe7-aaf2-e1fe593ce332",
+          "id": "67C0D8C3-A723-4BDA-8998-20A5A8D9234D",
           "name": "Port 3",
           "partitioned": true,
           "partitions": [
             {
-              "id": "fa097f04-f9c6-42b0-8822-8a755c04b299",
+              "id": "FA5E89BC-2CF5-4DF0-91FE-5E8F1B6B511F",
               "name": "1",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -404,12 +405,12 @@
               "wwpn": null
             },
             {
-              "id": "aa7fe4b2-0002-4747-a117-53e934e8cab0",
+              "id": "7548CD36-4BF4-4CA9-BF57-6E02A452F527",
               "name": "2",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -419,12 +420,12 @@
               "wwpn": null
             },
             {
-              "id": "a6bfdbb6-29fb-4913-ba41-46a7b90078e9",
+              "id": "2075514F-4887-4D33-8829-26825FE318F6",
               "name": "3",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -434,12 +435,12 @@
               "wwpn": null
             },
             {
-              "id": "1b3df5de-a4b6-4e2e-aa55-dc23ef8e16d7",
+              "id": "CD71DA97-5AB9-4FB9-8C87-35045CF2C4BA",
               "name": "4",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -449,24 +450,22 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "fec4c017-07da-43f3-b7af-1afa956bbbe0",
+          "id": "4211A4E4-EE86-4EA7-8E7D-FF00DDAA4046",
           "name": "Port 4",
           "partitioned": true,
           "partitions": [
             {
-              "id": "bbfc1271-ae29-4c3e-9a5e-587a13cd3d68",
+              "id": "766E5E23-8467-4803-9C97-4BBFB9E28477",
               "name": "1",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -476,12 +475,12 @@
               "wwpn": null
             },
             {
-              "id": "2cedce7f-f197-450e-8345-cfcf6e0e5dd8",
+              "id": "31D807AD-6970-4FFC-A151-DECA8EBBE520",
               "name": "2",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -491,12 +490,12 @@
               "wwpn": null
             },
             {
-              "id": "bf12c288-e6a3-413f-8c57-1c7282df4736",
+              "id": "406D9B22-35A6-41C5-A92A-A2A3244DF5D3",
               "name": "3",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -506,12 +505,12 @@
               "wwpn": null
             },
             {
-              "id": "91396d9a-6ca2-4ff3-8ad8-bb3914ee0ec3",
+              "id": "A1DF6DD4-8A3E-4E1D-9C85-94EAC4644B0B",
               "name": "4",
-              "networks": null,
-              "networkObjects": [
+              "networks": [
 
               ],
+              "networkObjects": null,
               "minimum": 0,
               "maximum": 100,
               "lanMacAddress": null,
@@ -521,608 +520,12 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         }
-      ]
-    },
-    {
-      "id": "c18a4c5e-f130-449c-8c31-8a7c226f3301",
-      "name": "Fabric B",
-      "redundancy": false,
-      "enabled": false,
-      "nictype": "2",
-      "interfaces": [
-        {
-          "id": "a792a657-17b5-4693-9e09-6e46d9ae2748",
-          "name": "Port 1",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "cf607c90-2fbc-4ce3-bb7f-722aed294aa0",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "86a36b03-10fb-4fec-8253-8b58a6e9ca6c",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "796fc38d-467d-4ab9-8b82-0ab7e929a5c6",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "dea7b4c4-e586-44a5-a4c8-431267e8e51c",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "651e6342-d388-44d7-926d-ac4d1f372e83",
-          "name": "Port 2",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "8a74c4cd-ad40-4864-9d00-95dba1d417c2",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "4412d8c3-f16c-4a9f-9780-aaed7ffa5a17",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "772d9ec8-505f-49bd-a21d-2b8089783a13",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "340c8bc5-73ce-4b62-98a2-3d743d0cac68",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "506ae273-3aef-410e-b8c7-85ce0de02d92",
-          "name": "Port 3",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "4bcd56a5-db55-4908-956d-de9ccef4db5c",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "daa878d4-fcad-4321-ba8a-217f235895a0",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "395c17b6-8d5f-48ab-99f4-139a86f0bde0",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "51b0f35c-cec9-419f-9253-730fe50e592e",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "f3c70c3b-9b81-4fed-a5b7-662181ac9820",
-          "name": "Port 4",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "9071e493-372f-4eb8-b9ff-0ae85f946496",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "1aa8be14-4f06-4a9c-94ba-8f6e5c8cb5d8",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "32e50e00-269e-4fde-bbcd-9f7b3858fa6c",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "a50526a9-96d7-4d26-a1e4-c7af1e72d50d",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        }
-      ]
-    },
-    {
-      "id": "daa2cb31-d760-4e83-b0ba-e09af674f673",
-      "name": "Fabric C",
-      "redundancy": false,
-      "enabled": false,
-      "nictype": "2",
-      "interfaces": [
-        {
-          "id": "cd9b7948-3196-4580-b67b-4103d7be4a28",
-          "name": "Port 1",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "1a655078-39c9-4b24-ae71-9480e15d39d2",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "ef3b6328-7966-4fee-8be2-ddd5195c9e19",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "5969eaa8-78a4-4de2-9311-ec28eae1b9a8",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "8d633677-1814-40ed-8521-35e7a769570b",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "fdda9e2c-54fd-4a91-94f0-1510d0df03ad",
-          "name": "Port 2",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "0f31534e-d5d1-47fd-9ca2-8d59d65d3ddd",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "f363508a-6976-467f-8f8c-5529c6a83193",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "e2e1151c-4d57-43a3-9e0b-878cb369bf4e",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "4aa7e986-a5b5-4183-9656-955152789669",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "4f7be3f7-93fe-4462-950b-dc201b0c405b",
-          "name": "Port 3",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "51c3c4e1-57d0-4b11-8fad-eed033686da2",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "7df5926a-15dc-48bf-a627-d2ec4b4a628d",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "d1e0d5ba-852c-4aa1-8297-4cae6514c854",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "8b7b805e-c1d0-4e7a-adc2-f8cde5fd8f88",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "856f08d9-6ec1-4318-a67d-ed4a646ddb48",
-          "name": "Port 4",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "380f4b4f-ded4-4be2-a397-5578a87fd6f2",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "591f0c29-3948-41e9-a7f3-3f815715697a",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "fd0bdda0-0c9f-4abb-ac25-a250dc2e9431",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "fd5f3ba9-1336-4a03-84ec-21962e427c84",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        }
-      ]
+      ],
+      "fabrictype": "ethernet"
     }
-  ],
-  "interfaces": null
+  ]
 }

--- a/spec/fixtures/network_configuration/blade_unpartitioned.json
+++ b/spec/fixtures/network_configuration/blade_unpartitioned.json
@@ -1,678 +1,37 @@
 {
-  "id": "31d68fd3-b7ff-4ca8-8c35-1d229d20e600",
-  "servertype": "blade",
+  "id": "FD96EDFF-EE2B-4ABE-A0DC-D8FA373488D0",
+  "servertype": null,
   "fabrics": [
+
+  ],
+  "interfaces": [
     {
-      "id": "07cc1292-f197-4f43-9b3b-25bec971d1b9",
-      "name": "Fabric A",
-      "redundancy": true,
-      "enabled": true,
-      "nictype": "2",
-      "interfaces": [
-        {
-          "id": "f0aff7fd-c1b9-4b2b-9c5a-5eebc272f314",
-          "name": "Port 1",
-          "partitioned": false,
-          "partitions": [
-            {
-              "id": "b66b10dc-100f-4270-87f2-8ad9c6db48f5",
-              "name": "1",
-              "networks": [
-                "ff80808146056aa2014605840b3303e0"
-              ],
-              "networkObjects": [
-                {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
-                  "description": "",
-                  "type": "PXE",
-                  "vlanId": 20,
-                  "static": false,
-                  "staticNetworkConfiguration": null
-                }
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "e057823a-27cb-446c-9f9e-2abdcb254606",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "95a74c5b-0ce4-4360-841e-3c197dc00104",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "4867789c-afb9-4300-a993-74bfd07deaa7",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "8b3f96eb-0429-4584-a4e7-4249a05a4537",
-          "name": "Port 2",
-          "partitioned": false,
-          "partitions": [
-            {
-              "id": "b66b10dc-100f-4270-87f2-8ad9c6db48f5",
-              "name": "1",
-              "networks": [
-                "ff80808146056aa2014605840b3303e0"
-              ],
-              "networkObjects": [
-                {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
-                  "description": "",
-                  "type": "PXE",
-                  "vlanId": 20,
-                  "static": false,
-                  "staticNetworkConfiguration": null
-                }
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "e057823a-27cb-446c-9f9e-2abdcb254606",
-              "name": "2",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "95a74c5b-0ce4-4360-841e-3c197dc00104",
-              "name": "3",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "4867789c-afb9-4300-a993-74bfd07deaa7",
-              "name": "4",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "67fc897b-0524-4cd3-ad54-dc1767857cd4",
-          "name": "Port 3",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "a43e861b-b495-4e68-8ac9-57b07f901574",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "3b8a574b-3e7e-4d42-b390-8cbba279dde0",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "543f6ab8-46e3-46e8-8b32-88e791ce4747",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "41c0fc94-1b27-48f9-a42b-0e21bab85453",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "7e692c15-1cb0-47b9-b4bb-f1369b427973",
-          "name": "Port 4",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "0b705da0-cec3-4d84-ab7b-85fa12640f24",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "ddfd05df-c4f6-4b26-9086-99c7c9f36237",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "82cb84bd-f561-4805-b59c-fbc1625139b3",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "6c5dd320-f358-42c1-a211-55a0f8494b66",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        }
-      ]
-    },
-    {
-      "id": "908455f9-efa4-4442-b3d5-d1e3ade7b3f8",
-      "name": "Fabric B",
-      "redundancy": true,
-      "enabled": true,
-      "nictype": "2",
-      "interfaces": [
-        {
-          "id": "3ee8da44-61fc-4bd6-ab75-ef28b8b47125",
-          "name": "Port 1",
-          "partitioned": false,
-          "partitions": [
-            {
-              "id": "c75a5580-4ca3-43e1-b962-f51d21d33b00",
-              "name": "1",
-              "networks": [
-                "ff80808146056aa2014605840b3303e0"
-              ],
-              "networkObjects": [
-                {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
-                  "description": "",
-                  "type": "PXE",
-                  "vlanId": 20,
-                  "static": false,
-                  "staticNetworkConfiguration": null
-                }
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "a0479aaf-53f4-4226-86f2-c3fea4763b7b",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "6a9504c5-4fab-4c4d-8573-b7797bb3fb44",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "ec8dfb22-814d-4b07-bdc8-74e6b2cc0c11",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "640f9823-325d-42e6-8920-c2c1705cdf0c",
-          "name": "Port 2",
-          "partitioned": false,
-          "partitions": [
-            {
-              "id": "c75a5580-4ca3-43e1-b962-f51d21d33b00",
-              "name": "1",
-              "networks": [
-                "ff80808146056aa2014605840b3303e0"
-              ],
-              "networkObjects": [
-                {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
-                  "description": "",
-                  "type": "PXE",
-                  "vlanId": 20,
-                  "static": false,
-                  "staticNetworkConfiguration": null
-                }
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "a0479aaf-53f4-4226-86f2-c3fea4763b7b",
-              "name": "2",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "6a9504c5-4fab-4c4d-8573-b7797bb3fb44",
-              "name": "3",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "ec8dfb22-814d-4b07-bdc8-74e6b2cc0c11",
-              "name": "4",
-              "networks": [
-
-              ],
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "0bbb713a-6f82-435d-ab29-4a7f9bdeff2f",
-          "name": "Port 3",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "22ca92c8-95b5-49d4-8861-d0ca88647454",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "77beff64-c4a2-41e5-b406-e2776fe64a71",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "c1a9a126-a23a-46e3-9989-c0b841a5c0e1",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "d112829d-efae-467f-b519-bc4d9a423347",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        },
-        {
-          "id": "6904cf5a-1b97-4ae6-b712-b2123e729330",
-          "name": "Port 4",
-          "partitioned": true,
-          "partitions": [
-            {
-              "id": "33357f8f-0bdd-435a-93e5-5353c03c67be",
-              "name": "1",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "f2e26375-dff2-416b-b86a-c293c6ab3ec5",
-              "name": "2",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "33df30cc-f2cb-4bb7-8a2b-0b2d5095fb79",
-              "name": "3",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            },
-            {
-              "id": "9bb76907-81eb-4cda-91a8-128a1213813e",
-              "name": "4",
-              "networks": null,
-              "networkObjects": [
-
-              ],
-              "minimum": 0,
-              "maximum": 100,
-              "lanMacAddress": null,
-              "iscsiMacAddress": null,
-              "iscsiIQN": null,
-              "wwnn": null,
-              "wwpn": null
-            }
-          ],
-          "interfaces": null,
-          "enabled": false,
-          "redundancy": false,
-          "usedforfc": false,
-          "nictype": null
-        }
-      ]
-    },
-    {
-      "id": "f09cadc0-7f44-4c74-93b9-ac6a6a372490",
-      "name": "Fabric C",
+      "id": "2C7428B2-45FC-44BA-B5CD-90BD96DE470A",
+      "name": "Interface",
       "redundancy": false,
       "enabled": true,
-      "nictype": "2",
+      "fabrictype": "ethernet",
+      "partitioned": false,
+      "nictype": "2x10Gb",
       "interfaces": [
         {
-          "id": "374d1241-3332-49dc-8330-2376dfc077a6",
+          "id": "4B45FF8E-CFBF-48FD-B079-4D6BC8893991",
           "name": "Port 1",
           "partitioned": false,
           "partitions": [
             {
-              "id": "4ad629cb-4402-41eb-ba47-37dbc8ffadf8",
+              "id": "DBE43F75-C6AB-410B-B150-83943F245A82",
               "name": "1",
               "networks": [
-                "ff80808146056aa2014605840b3303e0"
+                "ff808081508c08e301508c60861e0643"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
+                  "id": "ff808081508c08e301508c60861e0643",
+                  "name": "PXEPOP",
                   "description": "",
                   "type": "PXE",
-                  "vlanId": 20,
+                  "vlanId": 18,
                   "static": false,
                   "staticNetworkConfiguration": null
                 }
@@ -686,9 +45,11 @@
               "wwpn": null
             },
             {
-              "id": "8eea6a99-e483-4bfd-b936-0f0684eba7f8",
+              "id": "5856C03A-4278-4104-AC3A-499DE2723AD5",
               "name": "2",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -701,9 +62,11 @@
               "wwpn": null
             },
             {
-              "id": "90e6e324-b78a-4332-b548-231fcb3b6f46",
+              "id": "F9CBAFA6-7313-4E44-B6F3-93F9740230DB",
               "name": "3",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -716,9 +79,11 @@
               "wwpn": null
             },
             {
-              "id": "4b875c11-0fc2-45ab-8112-5995e2d41587",
+              "id": "DC62FB48-400A-486B-AA20-D984E0AC0E5F",
               "name": "4",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -731,29 +96,27 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "153cee07-9abd-4ebd-bae9-c9b08fc722bf",
+          "id": "7BBF1B5A-ABC1-4B15-83C0-42E8AFDEDB8D",
           "name": "Port 2",
           "partitioned": false,
           "partitions": [
             {
-              "id": "490a3f1d-1971-426d-af3f-7f16e4910bdf",
+              "id": "4A3C2B1C-75F2-49E5-ADE1-564DB8F2D3DF",
               "name": "1",
               "networks": [
-                "ff80808146056aa2014605840b3303e0"
+                "ff808081508c08e301508c7f92b106c8"
               ],
               "networkObjects": [
                 {
-                  "id": "ff80808146056aa2014605840b3303e0",
-                  "name": "PXE 2",
+                  "id": "ff808081508c08e301508c7f92b106c8",
+                  "name": "Workload",
                   "description": "",
-                  "type": "PXE",
+                  "type": "PRIVATE_LAN",
                   "vlanId": 20,
                   "static": false,
                   "staticNetworkConfiguration": null
@@ -761,16 +124,18 @@
               ],
               "minimum": 0,
               "maximum": 100,
-              "lanMacAddress": null,
+              "lanMacAddress": "00:0E:AA:F9:00:03",
               "iscsiMacAddress": null,
               "iscsiIQN": null,
               "wwnn": null,
               "wwpn": null
             },
             {
-              "id": "c48b2277-64cb-4cd0-aa4e-6b5f77125781",
+              "id": "3EB59814-0457-4E3E-8C12-2CC8EA9D29CC",
               "name": "2",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -783,9 +148,11 @@
               "wwpn": null
             },
             {
-              "id": "5a90e04d-f5b9-4c7a-9ef8-ddf119356e6e",
+              "id": "5E978707-992E-482E-9FA7-1B5F2D56EA47",
               "name": "3",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -798,9 +165,11 @@
               "wwpn": null
             },
             {
-              "id": "f8abed95-0350-4736-8982-44504316c67c",
+              "id": "94259F3B-4A24-4496-8D22-07A81B8C7E52",
               "name": "4",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -813,21 +182,21 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "241e044c-000f-4978-8961-31c3eb0036c0",
+          "id": "C44ED627-6A5C-4444-BBB3-6EF0EB3C99EF",
           "name": "Port 3",
-          "partitioned": true,
+          "partitioned": false,
           "partitions": [
             {
-              "id": "560334c0-c4b8-4c45-a802-c33763b25b46",
+              "id": "F5144A0C-CA71-400C-8E23-A5EAC7F6A91E",
               "name": "1",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -840,9 +209,11 @@
               "wwpn": null
             },
             {
-              "id": "044dc331-3200-4dbe-8061-6fce6a5ccb11",
+              "id": "4EB5E513-F021-4FB6-B508-621A3B6E8CD8",
               "name": "2",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -855,9 +226,11 @@
               "wwpn": null
             },
             {
-              "id": "70a294c2-bc7d-46e5-8ac3-59444bf3b074",
+              "id": "F37B8C26-20D2-4BBF-B7AB-5FA28DD6E757",
               "name": "3",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -870,9 +243,11 @@
               "wwpn": null
             },
             {
-              "id": "224ac359-42db-4252-adef-fdb257e941a0",
+              "id": "9CEFB2A2-7569-47B5-AF43-022E406AEE74",
               "name": "4",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -885,21 +260,21 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
-          "id": "55dfb864-3679-4aa5-ad91-9a36b73115e4",
+          "id": "1505BF77-6B94-41FB-BB21-8910AB059775",
           "name": "Port 4",
-          "partitioned": true,
+          "partitioned": false,
           "partitions": [
             {
-              "id": "493ce522-3a52-4d53-b632-58d8f6af064d",
+              "id": "63A20384-0ACD-4E6E-880B-56BE36AD4753",
               "name": "1",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -912,9 +287,11 @@
               "wwpn": null
             },
             {
-              "id": "c08793bd-e415-410a-8ee3-ef38aa15d6e3",
+              "id": "44CAE2A4-5686-44B0-B3D8-A06EF985F94D",
               "name": "2",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -927,9 +304,11 @@
               "wwpn": null
             },
             {
-              "id": "81bb7586-7677-44b4-b092-54068f56a660",
+              "id": "6E57EE01-0853-4C1D-AD5A-33A803BDF79B",
               "name": "3",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -942,9 +321,11 @@
               "wwpn": null
             },
             {
-              "id": "f74a6fdd-9e7f-4c69-a340-a14abb22811b",
+              "id": "2532712E-B518-4A36-BEE8-AF541C4E7A5C",
               "name": "4",
-              "networks": null,
+              "networks": [
+
+              ],
               "networkObjects": [
 
               ],
@@ -957,14 +338,12 @@
               "wwpn": null
             }
           ],
-          "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         }
-      ]
+      ],
+      "fabrictype": "ethernet"
     }
-  ],
-  "interfaces": null
+  ]
 }

--- a/spec/fixtures/network_configuration/rack_partitioned.json
+++ b/spec/fixtures/network_configuration/rack_partitioned.json
@@ -1297,8 +1297,8 @@
         }
       ],
       "enabled": true,
-      "redundancy": false,
-      "usedforfc": false,
+      "redundancy": true,
+      "fabrictype": "ethernet",
       "nictype": "2"
     },
     {
@@ -1376,7 +1376,6 @@
           "interfaces": null,
           "enabled": false,
           "redundancy": false,
-          "usedforfc": false,
           "nictype": null
         },
         {
@@ -1596,9 +1595,9 @@
           "nictype": null
         }
       ],
-      "enabled": true,
+      "enabled": false,
       "redundancy": false,
-      "usedforfc": true,
+      "fabrictype": "ethernet",
       "nictype": "2"
     }
   ]


### PR DESCRIPTION
Still some changes that need to be made later once the switch/blade code has been properly refactored.  There's some code in the switch configuration methods that still relies on the "is_blade?" method that should go away, but since it's being refactored already, there's not much point to redo that code ATM.