### PR TITLE
ASM-2058 detach ISO before checking LC ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,17 @@
-/.bundle/
-/.yardoc
-/Gemfile.lock
-/_yardoc/
-/coverage/
-/doc/
-/pkg/
-/spec/reports/
-/tmp/
+.vendor
+vendor
+Gemfile.lock
+*.gem
+*.log
+*~
+*.iml
+.rakeTasks
+.bundle
+.rspec
+.yardoc
+.ruby-version
+doc
+#Vim litter
+*.swo
+*.swp
 .idea


### PR DESCRIPTION
In ASM::WsMan.boot_to_network_iso, need to detach ISO before checking
LC ready. LC will always show as "not ready" if an ISO is currently
attached.