### PR TITLE
ASM-4621 choose best NICs to match NetworkConfiguration

### DIFF
--- a/lib/asm/network_configuration/nic_info.rb
+++ b/lib/asm/network_configuration/nic_info.rb
@@ -1,51 +1,177 @@
+require "asm/network_configuration/nic_port"
+
 module ASM
   class NetworkConfiguration
+    # NicInfo encapsulates information about a server NIC such as number of ports,
+    # link speed of those ports, and the number of NPAR partitions available on
+    # each port.
     class NicInfo
-      def initialize(fqdd, logger = nil)
-        @mash = parse_fqdd(fqdd, logger)
+      include Comparable
+
+      # Retrieves an array of NicInfo elements for the specified server endpoint.
+      #
+      # @param endpoint [Hash] the iDrac server endpoint. Should contain at least :host, :user and :password keys
+      # @param logger [Logger] logger to use for log messages
+      # @return [Array<NicInfo>] the NICs on the specified server
+      # @raise [StandardError] when an error occurs retrieving the NIC information
+      def self.fetch(endpoint, logger = nil)
+        nic_views = ASM::WsMan.get_nic_view(endpoint, logger)
+        bios_info = ASM::WsMan.get_bios_enumeration(endpoint, logger)
+        NicInfo.create(nic_views, bios_info, logger)
       end
 
-      # Create a new NicInfo based off self but with a different partition
-      def create_with_partition(partition)
-        NicInfo.new(@mash.fqdd.gsub(/[-]\d+$/, "-#{partition}"))
-      end
-
-      # Forward methods we don't define directly to the mash
-      def method_missing(sym, *args, &block)
-        @mash.send(sym, *args, &block)
-      end
-
-      def card_to_fabric(card)
-        ['A', 'B', 'C'][card.to_i - 1]
-      end
-
-      def parse_fqdd(fqdd, logger)
-        ret = Hashie::Mash.new
-        # Expected format: NIC.Mezzanine.2B-1-1
-        ret.fqdd = fqdd
-        (_, ret.type, port_info) = ret.fqdd.split('.')
-        (ret.card, ret.port, ret.partition_no) = port_info.split('-')
-        ret.partition_no = '1' if ret.partition_no.nil?
-        if ret.card =~ /([0-9])([A-Z])/
-          orig_card = ret.card
-          ret.card = $1
-          ret.fabric = $2
-          expected_fabric = card_to_fabric(orig_card)
-          if ret.fabric != expected_fabric
-            logger.warn("Mismatched fabric information for #{orig_card}: #{ret.fabric} versus #{expected_fabric}") if logger
-          end
-        else
-          if ret.type == 'Embedded'
-            ret.port = ret.card
-            ret.card = '1'
-          end
-          ret.fabric = card_to_fabric(ret.card)
+      # Retrieves an array of NicInfo elements for the specified nic_view and bios_information
+      #
+      # @param nic_views [Array<Hash>] the result of calling {ASM::WsMan.get_nic_view}
+      # @param bios_info [Array<Hash>] the result of calling {ASM::WsMan.get_bios_enumeration}
+      # @param logger [Logger] logger to use for log messages
+      # @return [Array<NicInfo>] the NIC info
+      # @raise [StandardError] when the nic_views are inconsistent
+      # @api private
+      def self.create(nic_views, bios_info, logger = nil)
+        prefix_to_views = {}
+        nic_views.each do |nic_view|
+          i = NicView.new(nic_view)
+          prefix_to_views[i.card_prefix] ||= []
+          prefix_to_views[i.card_prefix] << i
         end
-        ret
+
+        prefix_to_views.values.map do |nic_view|
+          NicInfo.new(nic_view.sort, bios_info, logger)
+        end.sort
       end
 
-      def card_prefix
-        "NIC.#{@mash.type}.#{@mash.card}"
+      attr_accessor :card_prefix, :vendor, :model, :ports, :nic_views, :nic_status
+
+      # Creates a NicInfo
+      #
+      # @param nic_views [Array<NicView>] the NicViews associated with the NIC
+      # @param bios_info [Array<Hash>] the BIOS enumeration for the server. Used
+      #                                to determine if the NIC is disabled.
+      # @param logger [Logger] logger to use for log messages
+      # @return [NicInfo] the NicInfo
+      # @raise [StandardError] when the nic_views are inconsistent
+      # @api private
+      def initialize(nic_views, bios_info, logger = nil)
+        @nic_views = nic_views.sort
+        NicInfo.validate_nic_views(nic_views)
+
+        port1 = nic_views.first
+        @card_prefix ||= port1.card_prefix
+        @vendor ||= port1.nic_view["VendorName"] # WARNING: sometimes this is missing! use PCIVendorID?
+        @model ||= port1.nic_view["ProductName"]
+
+        port_nic_views = nic_views.find_all { |i| i.partition_no == "1"}
+        @ports = port_nic_views.map do |nic_view|
+          NicPort.new(nic_view, port_nic_views.size, logger)
+        end
+
+        @nic_status = ASM::WsMan.nic_status(port1.fqdd, bios_info)
+      end
+
+      # Validates that the NIC NicView information is consistent
+      #
+      # Checks that all passed NicView information pertains to the same physical
+      # card and that there are no gaps, i.e. information is contained for all
+      # ports of the NIC and all partitions of those ports (if applicable).
+      #
+      # @raise [StandardError] if inconsistent NicView information was provided
+      # @api private
+      def self.validate_nic_views(nic_views)
+        port = nil
+        partition = nil
+        prefixes = nic_views.map(&:card_prefix).uniq
+        raise("No NIC information supplied") if nic_views.empty?
+        card_prefix = prefixes.first
+        raise("Cannot create single NicInfo for multiple cards: %s" % prefixes.join(", ")) if prefixes.size > 1
+
+        prev_fqdd = nic_views.first.fqdd
+        nic_views.each do |nic_view|
+          unless nic_view.card_prefix == card_prefix
+            raise("Card prefix should be %s but was %s" % [card_prefix, nic_view.card_prefix])
+          end
+          next_port = Integer(nic_view.port)
+          next_partition = Integer(nic_view.partition_no)
+          if port.nil? && partition.nil?
+            port = next_port
+            partition = next_partition
+          else
+            port_diff = next_port - port
+            if port_diff == 0 && next_partition != partition + 1
+              raise("Partition out of order between %s and %s" % [prev_fqdd, nic_view.fqdd])
+            elsif port_diff == 1 && next_partition != 1
+              raise("First partition for %s should be 1 but got %d" % [nic_view.fqdd, next_partition])
+            elsif !port_diff.between?(0, 1)
+              raise("Port out of order between %s and %s" % [prev_fqdd, nic_view.fqdd])
+            end
+            port = next_port
+            partition = next_partition
+            prev_fqdd = nic_view.fqdd
+          end
+        end
+      end
+
+      # If the NIC is disabled
+      #
+      # @return [Boolean]
+      def disabled?
+        !!(nic_status =~ /disabled/i)
+      end
+
+      # If all ports have the same link speed
+      #
+      # @param ports [Array<NicPort>] the ports
+      # @param link_speed [String] the link speed
+      # @return [Boolean] if all ports have the same link speed
+      def all_ports?(ports, link_speed)
+        ports.all? { |p| p.link_speed == link_speed }
+      end
+
+      # A string description of the NIC ports
+      #
+      # Example return values are 4x10Gb, 2x10Gb, 2x10Gb,2x1Gb, 2x1Gb or unknown.
+      #
+      # @return [String] the nic type description
+      def nic_type
+        return "2x10Gb" if ports.size == 2 && all_ports?(ports, "10 Gbps")
+        return "2x1Gb" if ports.size == 2 && all_ports?(ports, "1000 Mbps")
+        return "4x10Gb" if ports.size == 4 && all_ports?(ports, "10 Gbps")
+        return "4x1Gb" if ports.size == 4 && all_ports?(ports, "1000 Mbps")
+        return "2x10Gb,2x1Gb" if ports.size == 4 && all_ports?(ports.slice(0, 2), "10 Gbps") && all_ports?(ports.slice(2, 2), "1000 Mbps")
+        "unknown"
+      end
+
+      # The number of NPAR partitions for each 10Gb port on the NIC
+      #
+      # NICs that do not support NPAR will return 1
+      #
+      # @raise [StandardError] if different 10Gb ports report different partitioning capabilities
+      def n_partitions
+        ports_10gb = ports.find_all { |port| port.link_speed == "10 Gbps" }
+        return 1 if ports_10gb.empty? # Only 10Gb NICs support NPAR
+        ns = ports_10gb.map { |port| port.n_partitions }.uniq
+        return ns.first if ns.size == 1
+        raise("Different 10Gb NIC ports on %s reported different number of partitions: %s" %
+                  [card_prefix, ports_10gb.map { |p| "NIC: %s # partitions: %s" % [p.model, p.n_partitions] }.join(", ")])
+      end
+
+      # Returns the {NicView} for a specified port and partition
+      #
+      # @param port [String] the port number
+      # @param partition [String] the partition number
+      # @return [NicView|Void] the NicView if one can be found; nil otherwise
+      def find_partition(port, partition)
+        nic_views.find do |nic_view|
+          nic_view.port == port && nic_view.partition_no == partition
+        end
+      end
+
+      def to_s
+        "#<ASM::NetworkConfiguration::NicInfo %s type: %s model: %s>" % [card_prefix, nic_type, model]
+      end
+
+      def <=>(other)
+        self.ports.first <=> other.ports.first
       end
     end
   end

--- a/lib/asm/network_configuration/nic_port.rb
+++ b/lib/asm/network_configuration/nic_port.rb
@@ -1,0 +1,127 @@
+module ASM
+  class NetworkConfiguration
+    # NicPort encapsulates information about a server NIC port such as link speed
+    # and the number of NPAR partitions available on that port.
+    class NicPort
+
+      # The iDrac NICView LinkSpeed values
+      LINK_SPEEDS = [ "Unknown", "10 Mbps", "100 Mbps", "1000 Mbps", "2.5 Gbps", "10 Gbps", "20 Gbps", "40 Gbps", "100 Gbps" ]
+
+      attr_reader :link_speed, :n_ports, :nic_info
+
+      # Create a NicPort
+      #
+      # @param nic_view [NicView]
+      # @param n_ports [FixNum] the number of ports on the physical NIC
+      # @param logger [Logger] logger to use for log messages
+      # @return [NicPort]
+      def initialize(nic_view, n_ports, logger = nil)
+        @nic_info = nic_view
+        @n_ports = n_ports
+        nic_view = nic_view.nic_view
+        @vendor ||= nic_view["VendorName"] # WARNING: sometimes this is missing! use PCIVendorID?
+        @model ||= nic_view["ProductName"]
+        @link_speed = model_speed
+        @link_speed ||= LINK_SPEEDS[Integer(nic_view["LinkSpeed"])] if nic_view["LinkSpeed"]
+        @link_speed ||= LINK_SPEEDS[0]
+      end
+
+      # The vendor for the NIC port
+      #
+      # Currently only :qlogic and :intel vendors are recognized
+      #
+      # @return [Symbol|Void] the vendor or nil if none recognized
+      def vendor
+        nic_view = nic_info.nic_view
+        return :qlogic if nic_view["VendorName"] =~ /qlogic|broadcom/i
+        return :qlogic if nic_view["PCIVendorID"] == "14e4"
+        return :intel if nic_view["VendorName"] =~ /intel/i
+        :intel if nic_view["PCIVendorID"] == "8086" # have seen cases where VendorName not populated
+      end
+
+      # The product name of the NIC port
+      #
+      # @return [String|Void] the product name or nil if none recognized
+      def product
+        nic_info.nic_view["ProductName"]
+      end
+
+      # The port number
+      #
+      # @return [FixNum] the port number
+      def port
+        Integer(nic_info.port)
+      end
+
+      # Whether the NIC port belongs to a Broadcom / QLogic 57800 NIC
+      #
+      # @return [Boolean]
+      def is_qlogic_57800?
+        vendor == :qlogic && product =~ /(^|\D)57800(|\D|$)/ && n_ports == 4
+      end
+
+      # Whether the NIC port belongs to a Broadcom / QLogic 57810 NIC
+      #
+      # @return [Boolean]
+      def is_qlogic_57810?
+        vendor == :qlogic && product =~ /(^|\D)57810(\D|$)/ && n_ports == 2
+      end
+
+      # Whether the NIC port belongs to a Broadcom / QLogic 57840 NIC
+      #
+      # @return [Boolean]
+      def is_qlogic_57840?
+        vendor == :qlogic && product =~ /(^|\D)57840(\D|$)/ && n_ports == 4
+      end
+
+      # Whether the NIC port belongs to a 2x10Gb Intel X520 NIC
+      #
+      # Note that there appear to be many X520 variants. This method only returns
+      # true for 2x10Gb X520 NICs
+      #
+      # @return [Boolean]
+      def is_intel_x520?
+        vendor == :intel && product =~ /x520(\D|$)/i && n_ports == 2
+      end
+
+      # The NIC port speed as determined by NIC vendor and model information
+      #
+      # Currently recognizes speed values for Broadcom 57800, 57810 and 57840
+      # and 2x10Gb Intel X520 NICs. Returns nil for all other NIC models.
+      #
+      # @return [String|Void] The link speed for recognized NIC models, nil otherwise.
+      def model_speed
+        return "10 Gbps" if is_qlogic_57810?
+        return "10 Gbps" if is_qlogic_57840?
+
+        # Broadcom / QLogic 57800 is a 2x10Gb, 2x1Gb NIC
+        return "10 Gbps" if is_qlogic_57800? && port.between?(1, 2)
+        return "1000 Mbps" if is_qlogic_57800? && port.between?(3, 4)
+
+        return "10 Gbps" if is_intel_x520?
+        nil
+      end
+
+      # The number of NPAR partitions possible on the port
+      #
+      # Currently recognizes NPAR values for Broadcom 57800, 57810 and 57840 NICs.
+      # All other NICs report a value of 1.
+      #
+      # @return [FixNum] the maximum number of NPAR partitions for the port
+      def n_partitions
+        return 4 if is_qlogic_57810?
+        return 2 if is_qlogic_57840?
+        return 2 if is_qlogic_57800? && port.between?(1, 2)
+        1
+      end
+
+      def to_s
+        "#<ASM::NetworkConfiguration::NicPort %s product: %s port: %d>" % [nic_info.fqdd, product, port]
+      end
+
+      def <=>(other)
+        self.nic_info <=> other.nic_info
+      end
+    end
+  end
+end

--- a/lib/asm/network_configuration/nic_type.rb
+++ b/lib/asm/network_configuration/nic_type.rb
@@ -13,12 +13,14 @@ module ASM
       # @param nictype [String]
       # @return [ASM::NicType]
       def initialize(nictype)
-        @nictype = nictype
         @ports = nictype.split(",").map(&:strip).map do |desc|
           n, type = desc.split("x")
           type ||= "10Gb"
           Array.new(n.to_i, type)
         end.flatten
+        @nictype = nictype
+        @nictype = "2x10Gb" if nictype == "2"
+        @nictype = "4x10Gb" if nictype == "4"
       end
 
       def n_10gb_ports

--- a/lib/asm/network_configuration/nic_view.rb
+++ b/lib/asm/network_configuration/nic_view.rb
@@ -1,0 +1,80 @@
+require "hashie"
+
+module ASM
+  class NetworkConfiguration
+    class NicView
+      include Comparable
+
+      attr_accessor :nic_view
+
+      def initialize(fqdd, logger = nil)
+        if fqdd.is_a?(Hash)
+          @nic_view = fqdd
+          fqdd = fqdd["FQDD"]
+        end
+        @mash = parse_fqdd(fqdd, logger)
+      end
+
+      # Create a new NicInfo based off self but with a different partition
+      def create_with_partition(partition)
+        NicView.new(@mash.fqdd.gsub(/[-]\d+$/, "-#{partition}"))
+      end
+
+      # Forward methods we don't define directly to the mash
+      def method_missing(sym, *args, &block)
+        @mash.send(sym, *args, &block)
+      end
+
+      def card_to_fabric(card)
+        ['A', 'B', 'C'][card.to_i - 1]
+      end
+
+      def parse_fqdd(fqdd, logger)
+        ret = Hashie::Mash.new
+        # Expected format: NIC.Mezzanine.2B-1-1
+        ret.fqdd = fqdd
+        (_, ret.type, port_info) = ret.fqdd.split('.')
+        (ret.card, ret.port, ret.partition_no) = port_info.split('-')
+        ret.partition_no = '1' if ret.partition_no.nil?
+        if ret.card =~ /([0-9])([A-Z])/
+          orig_card = ret.card
+          ret.card = $1
+          ret.fabric = $2
+          expected_fabric = card_to_fabric(orig_card)
+          if ret.fabric != expected_fabric
+            logger.warn("Mismatched fabric information for #{orig_card}: #{ret.fabric} versus #{expected_fabric}") if logger
+          end
+        else
+          if ret.type == 'Embedded'
+            ret.port = ret.card
+            ret.card = '1'
+          end
+          ret.fabric = card_to_fabric(ret.card)
+        end
+        ret
+      end
+
+      def card_prefix
+        "NIC.#{@mash.type}.#{@mash.card}"
+      end
+
+      def to_s
+        "#<ASM::NetworkConfiguration::NicInfo fqdd: %s>" % fqdd
+      end
+
+      def <=>(other)
+        ret = self.type <=> other.type
+        if ret == 0
+          ret = Integer(self.card) <=> Integer(other.card)
+          if ret == 0
+            ret = Integer(self.port) <=> Integer(other.port)
+            if ret == 0
+              ret = Integer(self.partition_no) <=> Integer(other.partition_no)
+            end
+          end
+        end
+        ret
+      end
+    end
+  end
+end

--- a/spec/unit/asm/network_configuration/nic_info_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_info_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+require 'asm/network_configuration'
+
+
+describe ASM::NetworkConfiguration::NicInfo do
+  let(:logger) { stub(:debug => nil, :warn => nil, :info => nil) }
+  let(:endpoint) { mock("rspec-endpoint") }
+  let(:integrated_4x10gb_nic_views) do
+    1.upto(4).map do |i|
+      {"FQDD" => "NIC.Integrated.1-%d-1" % i,
+       "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+       "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+       "VendorName" => "Broadcom",
+       "ProductName" => "57840"}
+    end
+  end
+  let(:integrated_2x10gb_partitioned_nic_views) do
+    1.upto(2).map do |port|
+      1.upto(4).map do |partition|
+        {"FQDD" => "NIC.Integrated.1-%d-%d" % [port, partition],
+         "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % port,
+         "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %port,
+         "VendorName" => "Broadcom",
+         "ProductName" => "57810"}
+      end
+    end.flatten
+  end
+  let(:mezz_2x10gb_nic_views) do
+    1.upto(2).map do |i|
+      {"FQDD" => "NIC.Mezzanine.2B-%d-1" % i,
+       "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+       "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+       "VendorName" => "Broadcom",
+       "ProductName" => "57810"}
+    end
+  end
+
+  describe "#ASM::NetworkConfiguration::NicInfo" do
+    describe ".fetch" do
+      it "should create NicInfo based on NicView and BiosEnumeration" do
+        ASM::WsMan.expects(:get_nic_view).with(endpoint, logger).returns("rspec_nic_views")
+        ASM::WsMan.expects(:get_bios_enumeration).with(endpoint, logger).returns("rspec_bios_info")
+        ASM::NetworkConfiguration::NicInfo.expects(:create).with("rspec_nic_views", "rspec_bios_info", logger)
+        ASM::NetworkConfiguration::NicInfo.fetch(endpoint, logger)
+      end
+    end
+
+    describe ".create" do
+      it "should create NicInfos in correct order" do
+        nic_views = integrated_4x10gb_nic_views + mezz_2x10gb_nic_views
+        nic_views.reverse
+        ret = ASM::NetworkConfiguration::NicInfo.create(nic_views, [], logger)
+        expect(ret.size).to eq(2)
+        expect(ret[0].model).to eq("57840")
+        expect(ret[1].model).to eq("57810")
+      end
+    end
+
+    describe "#initialize" do
+      let(:nic_views) { mezz_2x10gb_nic_views.map { |n| ASM::NetworkConfiguration::NicView.new(n) } }
+
+      it "should validate_nic_view" do
+        nic_views = mezz_2x10gb_nic_views.map { |n| ASM::NetworkConfiguration::NicView.new(n) }
+        ASM::NetworkConfiguration::NicInfo.expects(:validate_nic_views).with(nic_views)
+        ASM::NetworkConfiguration::NicInfo.new(nic_views, [], logger)
+      end
+
+      it "should set nic_status" do
+        ASM::WsMan.expects(:nic_status).with(nic_views.first.fqdd, []).returns(true)
+        info = ASM::NetworkConfiguration::NicInfo.new(nic_views, [], logger)
+        expect(info.nic_status).to eq(true)
+      end
+    end
+
+    describe "#validate_nic_views" do
+      it "should fail if nic views from different nic cards" do
+        fqdds = %w(NIC.Integrated.1-1-1 NIC.Slot.8-1-1)
+        views = fqdds.map { |fqdd| ASM::NetworkConfiguration::NicView.new(fqdd) }
+        expect do
+          ASM::NetworkConfiguration::NicInfo.validate_nic_views(views)
+        end.to raise_error("Cannot create single NicInfo for multiple cards: NIC.Integrated.1, NIC.Slot.8")
+      end
+
+      it "should fail if missing ports" do
+        nic_views = integrated_4x10gb_nic_views.map do |nic_view|
+          n = ASM::NetworkConfiguration::NicView.new(nic_view)
+          n unless n.port == "3"
+        end.compact
+
+        expect do
+          ASM::NetworkConfiguration::NicInfo.validate_nic_views(nic_views)
+        end.to raise_error("Port out of order between NIC.Integrated.1-2-1 and NIC.Integrated.1-4-1")
+      end
+
+      it "should fail if missing partitions" do
+        nic_views = integrated_2x10gb_partitioned_nic_views.map do |nic_view|
+          n = ASM::NetworkConfiguration::NicView.new(nic_view)
+          n unless n.port == "1" && n.partition_no == "3"
+        end.compact
+
+        expect do
+          ASM::NetworkConfiguration::NicInfo.validate_nic_views(nic_views)
+        end.to raise_error("Partition out of order between NIC.Integrated.1-1-2 and NIC.Integrated.1-1-4")
+      end
+
+      it "should fail if first partition is not 1" do
+        nic_views = integrated_2x10gb_partitioned_nic_views.map do |nic_view|
+          n = ASM::NetworkConfiguration::NicView.new(nic_view)
+          n unless n.port == "2" && n.partition_no == "1"
+        end.compact
+
+        expect do
+          ASM::NetworkConfiguration::NicInfo.validate_nic_views(nic_views)
+        end.to raise_error("First partition for NIC.Integrated.1-2-2 should be 1 but got 2")
+      end
+    end
+
+    def build_nic_info(nic_views)
+      nic_views = nic_views.map { |n| ASM::NetworkConfiguration::NicView.new(n) }
+      ASM::NetworkConfiguration::NicInfo.new(nic_views, [], logger)
+    end
+
+    describe "#disabled?" do
+      let(:nic_info) { build_nic_info(integrated_2x10gb_partitioned_nic_views) }
+
+      it "should return true if nic_status contains disabled" do
+        nic_info.expects(:nic_status).returns("Disabled")
+        expect(nic_info.disabled?).to eq(true)
+      end
+
+      it "should return false otherwise" do
+        nic_info.expects(:nic_status).returns("Enabled")
+        expect(nic_info.disabled?).to eq(false)
+      end
+    end
+
+    describe "#nic_type" do
+      it "should recognize 2x10Gb" do
+        nic_info = build_nic_info(integrated_2x10gb_partitioned_nic_views)
+        expect(nic_info.nic_type).to eq("2x10Gb")
+      end
+
+      it "should recognize 2x1Gb" do
+        nic_views = 1.upto(2).map do |i|
+          {"FQDD" => "NIC.Embedded.1-%d-1" % i,
+           "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+           "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+           "LinkSpeed" => "3"}
+        end
+        nic_info = build_nic_info(integrated_2x10gb_partitioned_nic_views)
+        expect(nic_info.nic_type).to eq("2x10Gb")
+      end
+
+      it "should recognize 4x10Gb" do
+        nic_info = build_nic_info(integrated_4x10gb_nic_views)
+        expect(nic_info.nic_type).to eq("4x10Gb")
+      end
+
+      it "should recognize 2x10Gb,2x1Gb" do
+        nic_views = 1.upto(4).map do |i|
+          {"FQDD" => "NIC.Integrated.1-%d-1" % i,
+           "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+           "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+           "LinkSpeed" => i < 3 ? "5" : "3"}
+        end
+        nic_info = build_nic_info(nic_views)
+        expect(nic_info.nic_type).to eq("2x10Gb,2x1Gb")
+      end
+
+      it "should return unknown otherwise" do
+        nic_views = 1.upto(2).map do |i|
+          {"FQDD" => "NIC.Integrated.1-%d-1" % i,
+           "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+           "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i}
+        end
+        nic_info = build_nic_info(nic_views)
+        # unknown because no LinkSpeed or known vendor/model
+        expect(nic_info.nic_type).to eq("unknown")
+      end
+    end
+
+    describe "#n_partitions" do
+      it "should return 1 for 1Gb NICs" do
+        nic_views = 1.upto(2).map do |i|
+          {"FQDD" => "NIC.Slot.1-%d-1" % i,
+           "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+           "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+           "LinkSpeed" => "3"}
+        end
+        nic_info = build_nic_info(nic_views)
+        expect(nic_info.n_partitions).to eq(1)
+      end
+
+      it "should return 4 if all ports have 4 parititons" do
+        nic_info = build_nic_info(integrated_2x10gb_partitioned_nic_views)
+        expect(nic_info.n_partitions).to eq(4)
+      end
+
+      it "should return 2 for broadcom 57800" do
+        nic_views = 1.upto(4).map do |i|
+          {"FQDD" => "NIC.Integrated.1-%d-1" % i,
+           "CurrentMACAddress" => "04:0A:F7:06:88:5%d" % i,
+           "PermanentMACAddress" => "04:0A:F7:06:88:5%d" %i,
+           "VendorName" => "Broadcom",
+           "ProductName" => "57800"}
+        end
+        nic_info = build_nic_info(nic_views)
+        expect(nic_info.n_partitions).to eq(2)
+      end
+    end
+
+    describe "#<=>" do
+      it "should order the cards" do
+        integrated1 = build_nic_info(integrated_4x10gb_nic_views)
+        mezz2 = build_nic_info(mezz_2x10gb_nic_views)
+        expect(integrated1 <=> mezz2).to eq(-1)
+        expect(mezz2 <=> integrated1).to eq(1)
+        expect(mezz2 <=> mezz2).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/unit/asm/network_configuration/nic_port_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_port_spec.rb
@@ -1,0 +1,166 @@
+require "spec_helper"
+require "asm/network_configuration/nic_view"
+require "asm/network_configuration/nic_port"
+
+describe ASM::NetworkConfiguration::NicPort do
+  let(:logger) { stub(:debug => nil, :warn => nil, :info => nil, :error => nil) }
+
+  describe "NicPort.new" do
+    let (:endpoint) { mock("rspec-endpoint") }
+
+    it "should use LinkSpeed for 10Gbps NIC" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "LinkSpeed" => "5"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 1, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should use LinkSpeed for 1Gbps NIC" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "LinkSpeed" => "3"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 1, logger)
+      expect(port.link_speed).to eq("1000 Mbps")
+    end
+
+    it "should override Broadcom 57800 LinkSpeed for port 1 to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57800"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 4, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should override Broadcom 57800 LinkSpeed for port 3 to 1000 Mbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-3-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57800"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 4, logger)
+      expect(port.link_speed).to eq("1000 Mbps")
+    end
+
+    it "should override Broadcom 57810 LinkSpeed for port 1 of 2-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57810"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should not override Broadcom 57810 LinkSpeed for port 1 of 4-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57810"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 4, logger)
+      expect(port.link_speed).to eq("Unknown")
+    end
+
+    it "should override Broadcom 57840 LinkSpeed for port 3 of 4-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-3-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57840"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 4, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should not override Broadcom 57840 LinkSpeed for port 3 of 2-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-3-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57840"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger)
+      expect(port.link_speed).to eq("Unknown")
+    end
+
+    it "should override Intel X520 LinkSpeed for port 2 of 2-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-2-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Intel",
+                  "ProductName" => "X520"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should override Intel X520 LinkSpeed for port 2 of 2-port NIC to 10 Gbps when only PCIVendorID available" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-2-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "PCIVendorID" => "8086",
+                  "ProductName" => "X520"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should not override Intel X520 LinkSpeed for port 1 of 4-port NIC to 10 Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Intel",
+                  "ProductName" => "X520"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 4, logger)
+      expect(port.link_speed).to eq("Unknown")
+    end
+
+    it "should prefer model speed to ws-man LinkSpeed" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "LinkSpeed" => "3", # 1 Gbps, but model is 10Gbps
+                  "VendorName" => "Broadcom",
+                  "ProductName" => "57810"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+  end
+
+  describe "#n_partitions" do
+    let (:nic_info) { ASM::NetworkConfiguration::NicView.new({"FQDD" => "NIC.Integrated.1-1-1"}) }
+    let (:nic_port) { ASM::NetworkConfiguration::NicPort.new(nic_info, 2, logger) }
+
+    it "should return 2 for QLogic 57800" do
+      nic_port.expects(:is_qlogic_57800?).returns(true)
+      expect(nic_port.n_partitions).to eq(2)
+    end
+
+    it "should return 4 for QLogic 57810" do
+      nic_port.expects(:is_qlogic_57810?).returns(true)
+      expect(nic_port.n_partitions).to eq(4)
+    end
+
+    it "should return 2 for QLogic 57840" do
+      nic_port.expects(:is_qlogic_57840?).returns(true)
+      expect(nic_port.n_partitions).to eq(2)
+    end
+
+    it "should return 1 otherwise" do
+      expect(nic_port.n_partitions).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Previously server NICs were assigned to NetworkConfiguration
interfaces solely based on NIC order. I.e. if the user chose a 4x10Gb
NIC and and 2x10Gb NIC it was assumed that the server should have a
4x10Gb NIC before a 2x10Gb NIC according to slot order. New versions
of ASM allow more flexible NIC matching, i.e. in the previous example
a server that had a 2x10Gb NIC before a 4x10Gb NIC would also be
matched.

This commmit updates ASM::NetworkConfiguration to match NICs in a
similar fashion based on NIC capabilities. For each NIC requested in
the NetworkConfiguration a server NIC with matching capabilities (link
speed and number of NPAR partitions) will be found.

Link speed can be determined programatically via WS-Man in most
cases. However, if not available this code will fall back to
hard-coded information based on certain known NIC models such as the
Broadcom / QLogic 578xx series or the Intel X520. Number of NPAR
partitions can only be determined based on hard-coded NIC model
information for the Broadcom 578xx series; all other NICs are treated
as not supporting NPAR.