### PR TITLE
ASM-5219 new ISO commands and better response parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,90 @@
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/WordArray:
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/SpaceInsideBlockBraces:
+  Enabled: false
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Style/Documentation:
+  Severity: warning
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/PredicateName:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 180
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 50
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+lib/**/*.rb
+nagios/check_snmp.rb
+-

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ task :default => 'spec:suite:unit'
 # To run unit tests:                 bundle exec rake spec:suite:unit
 
 namespace :spec do
-
   namespace :suite do
     desc 'Run all specs in unit spec suite'
     RSpec::Core::RakeTask.new('unit') do |t|
@@ -22,14 +21,14 @@ namespace :spec do
   end
 end
 
-# namespace :doc do
-#   desc "Serve YARD documentation on %s:%d" % [ENV.fetch("YARD_BIND", "127.0.0.1"), ENV.fetch("YARD_PORT", "9292")]
-#   task :serve do
-#     system("yard server --reload --bind %s --port %d" % [ENV.fetch("YARD_BIND", "127.0.0.1"), ENV.fetch("YARD_PORT", "9292")])
-#   end
-#
-#   desc "Generate documentatin into the %s" % ENV.fetch("YARD_OUT", "doc")
-#   task :yard do
-#     system("yard doc --output-dir %s" % ENV.fetch("YARD_OUT", "doc"))
-#   end
-# end
+namespace :doc do
+  desc "Serve YARD documentation on %s:%d" % [ENV.fetch("YARD_BIND", "127.0.0.1"), ENV.fetch("YARD_PORT", "9293")]
+  task :serve do
+    system("yard server --reload --bind %s --port %d" % [ENV.fetch("YARD_BIND", "127.0.0.1"), ENV.fetch("YARD_PORT", "9293")])
+  end
+
+  desc "Generate documentatin into the %s" % ENV.fetch("YARD_OUT", "doc")
+  task :yard do
+    system("yard doc --output-dir %s" % ENV.fetch("YARD_OUT", "doc"))
+  end
+end

--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logger-colors', '~> 1.0.0'
   s.add_development_dependency 'guard-shell'
   s.add_development_dependency 'yard'
+  s.add_development_dependency 'kramdown'
+  s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rspec', '~>2.14.0'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'puppet'

--- a/spec/fixtures/wsman/connect_network_iso.xml
+++ b/spec/fixtures/wsman/connect_network_iso.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:n1="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService/ConnectNetworkISOImageResponse</wsa:Action>
+        <wsa:RelatesTo>uuid:52bb5a7f-26a7-16a7-8002-34e5aa565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:5a5eb66f-26ac-16ac-a7a6-d46bf0fa8c00</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <n1:ConnectNetworkISOImage_OUTPUT>
+            <n1:Job>
+                <wsa:EndpointReference>
+                    <wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address>
+                    <wsa:ReferenceParameters>
+                        <wsman:ResourceURI>http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_OSDConcreteJob</wsman:ResourceURI>
+                        <wsman:SelectorSet>
+                            <wsman:Selector Name="InstanceID">DCIM_OSDConcreteJob:1</wsman:Selector>
+                            <wsman:Selector Name="__cimnamespace">root/dcim</wsman:Selector>
+                        </wsman:SelectorSet>
+                    </wsa:ReferenceParameters>
+                </wsa:EndpointReference>
+            </n1:Job>
+            <n1:ReturnValue>4096</n1:ReturnValue>
+        </n1:ConnectNetworkISOImage_OUTPUT>
+    </s:Body>
+</s:Envelope>

--- a/spec/fixtures/wsman/fault.xml
+++ b/spec/fixtures/wsman/fault.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</wsa:Action>
+        <wsa:RelatesTo>uuid:eceb0b97-26c9-16c9-8002-34e5aa565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:f49f08c6-26ce-16ce-a5df-d46bf0fa8c00</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <s:Fault>
+            <s:Code>
+                <s:Value>s:Sender</s:Value>
+                <s:Subcode>
+                    <s:Value>wsman:InvalidParameter</s:Value>
+                </s:Subcode>
+            </s:Code>
+            <s:Reason>
+                <s:Text xml:lang="en">CMPI_RC_ERR_INVALID_PARAMETER</s:Text>
+            </s:Reason>
+            <s:Detail>
+                <wsman:FaultDetail>http://schemas.dmtf.org/wbem/wsman/1/wsman/faultDetail/MissingValues</wsman:FaultDetail>
+            </s:Detail>
+        </s:Fault>
+    </s:Body>
+</s:Envelope>

--- a/spec/fixtures/wsman/get_attach_status.xml
+++ b/spec/fixtures/wsman/get_attach_status.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:n1="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService/DisconnectNetworkISOImageResponse</wsa:Action>
+        <wsa:RelatesTo>uuid:85ac9fe2-26c9-16c9-8002-34e5aa565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:8d901a2a-26ce-16ce-a51f-d46bf0fa8c00</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <n1:DisconnectNetworkISOImage_OUTPUT>
+            <n1:ReturnValue>0</n1:ReturnValue>
+        </n1:DisconnectNetworkISOImage_OUTPUT>
+    </s:Body>
+</s:Envelope>

--- a/spec/fixtures/wsman/osd_concrete_job.xml
+++ b/spec/fixtures/wsman/osd_concrete_job.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_OSDConcreteJob" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</wsa:Action>
+        <wsa:RelatesTo>uuid:392d8e46-26ca-16ca-8002-34e5aa565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:40e91dda-26cf-16cf-a67e-d46bf0fa8c00</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <n1:DCIM_OSDConcreteJob>
+            <n1:DeleteOnCompletion>false</n1:DeleteOnCompletion>
+            <n1:InstanceID>DCIM_OSDConcreteJob:1</n1:InstanceID>
+            <n1:JobName>BootToNetworkISO</n1:JobName>
+            <n1:JobStatus>Rebooting to ISO</n1:JobStatus>
+            <n1:Message xsi:nil="true"/>
+            <n1:MessageID xsi:nil="true"/>
+            <n1:Name>BootToNetworkISO</n1:Name>
+        </n1:DCIM_OSDConcreteJob>
+    </s:Body>
+</s:Envelope>

--- a/spec/fixtures/wsman/timed_out_fault.xml
+++ b/spec/fixtures/wsman/timed_out_fault.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</wsa:Action>
+        <wsa:RelatesTo>uuid:a3ec4d09-24ed-14ed-8002-07bd8a565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:a7c77dc1-24ed-14ed-97ef-e728defe83b0</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <s:Fault>
+            <s:Code>
+                <s:Value>s:Receiver</s:Value>
+                <s:Subcode>
+                    <s:Value>wsman:TimedOut</s:Value>
+                </s:Subcode>
+            </s:Code>
+            <s:Reason>
+                <s:Text xml:lang="en">The operation has timed out.</s:Text>
+            </s:Reason>
+        </s:Fault>
+    </s:Body>
+</s:Envelope>

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 require 'asm/wsman'
 
 describe ASM::WsMan do
+  let(:logger) { stub(:debug => nil, :warn => nil, :info => nil) }
+  let(:endpoint) { {:host => "rspec-host", :user => "rspec-user", :password => "rspec-password"} }
 
   describe 'when parsing nicview with disabled 57800 and dual-port slot nic' do
-
     before do
       # NOTE: this data is from a rack with a dual-port slot nic and a quad-port
       # integrated nic. Note the quad-port nic isn't showing any current or
@@ -70,46 +71,256 @@ describe ASM::WsMan do
     end
   end
 
-  describe "#detach_network_iso" do
-    it "should invoke DetachIISOImage" do
-      endpoint = mock()
-      logger = mock()
-      ASM::WsMan.expects(:invoke).with(endpoint, "DetachISOImage", ASM::WsMan::DEPLOYMENT_SERVICE_SCHEMA, :logger => logger)
-      ASM::WsMan.detach_network_iso(endpoint, logger)
+  describe "#response_string" do
+    it "should display message" do
+      resp = {:lcstatus => "5",
+              :message => "Lifecycle Controller Remote Services is not ready."}
+      expect(ASM::WsMan.response_string(resp)).to eq("Lifecycle Controller Remote Services is not ready. [lcstatus: 5]")
     end
   end
 
-  describe "#boot to_network_iso" do
-    let(:logger) { stub(:debug => nil, :warn => nil, :info => nil) }
-    let(:endpoint) { mock("rspec-endpoint") }
-
-    it "should detach iso, wait for lc and boot network iso" do
-      ASM::WsMan.expects(:detach_network_iso).with(endpoint, logger)
-      ASM::WsMan.expects(:wait_for_lc_ready).with(endpoint, logger)
-      ASM::WsMan.expects(:wait_for_iso_boot).with(endpoint, logger)
-      props = {'IPAddress' => "rspec-ip",
-               'ShareName' => "/var/rspec",
-               'ShareType' => 0,
-               'ImageName' => "rspec-microkernel.iso"}
-      ASM::WsMan.expects(:invoke).with(endpoint, "BootToNetworkISO",
-                                       ASM::WsMan::DEPLOYMENT_SERVICE_SCHEMA,
-                                       :logger => logger, :props => props, :selector => '//n1:ReturnValue').returns("4096")
-      ASM::WsMan.boot_to_network_iso(endpoint, "rspec-ip", logger, "rspec-microkernel.iso", "/var/rspec")
+  describe "ResponseError#to_s" do
+    it "should display message" do
+      e = ASM::WsMan::ResponseError.new("Exception message", {:message => "ws-man message", :message_id => "4"})
+      expect(e.to_s).to eq("Exception message: ws-man message [message_id: 4]")
     end
 
-    it "should fail with invalid response code" do
-      ASM::WsMan.expects(:detach_network_iso).with(endpoint, logger)
-      ASM::WsMan.expects(:wait_for_lc_ready).with(endpoint, logger)
-      props = {'IPAddress' => "rspec-ip",
-               'ShareName' => "/var/rspec",
-               'ShareType' => 0,
-               'ImageName' => "rspec-microkernel.iso"}
-      ASM::WsMan.expects(:invoke).with(endpoint, "BootToNetworkISO",
-                                       ASM::WsMan::DEPLOYMENT_SERVICE_SCHEMA,
-                                       :logger => logger, :props => props, :selector => '//n1:ReturnValue').returns("FAIL")
+    it "should display fault reason" do
+      e = ASM::WsMan::ResponseError.new("Exception message", {:reason => "ws-man fault reason", :message_id => "4"})
+      expect(e.to_s).to eq("Exception message: ws-man fault reason [message_id: 4]")
+    end
+
+    it "should prefer message to fault reason" do
+      resp = {:message => "ws-man message", :reason => "ws-man fault reason", :message_id => "4"}
+      e = ASM::WsMan::ResponseError.new("Exception message", resp)
+      expect(e.to_s).to eq("Exception message: ws-man message [reason: ws-man fault reason, message_id: 4]")
+    end
+  end
+
+  describe "#parse" do
+    it "should parse simple responses" do
+      content = SpecHelper.load_fixture("wsman/get_attach_status.xml")
+      expect(ASM::WsMan.parse(content)).to eq({:return_value => "0"})
+    end
+
+    it "should parse job status responses" do
+      content = SpecHelper.load_fixture("wsman/connect_network_iso.xml")
+      expected = {:job => "DCIM_OSDConcreteJob:1",
+                  :return_value => "4096"}
+      expect(ASM::WsMan.parse(content)).to eq(expected)
+    end
+
+    it "should parse faults" do
+      content = SpecHelper.load_fixture("wsman/fault.xml")
+      expected = {:code => "wsman:InvalidParameter",
+                  :reason => "CMPI_RC_ERR_INVALID_PARAMETER",
+                  :detail => "http://schemas.dmtf.org/wbem/wsman/1/wsman/faultDetail/MissingValues"}
+      expect(ASM::WsMan.parse(content)).to eq(expected)
+    end
+
+    it "should parse timed out fault" do
+      content = SpecHelper.load_fixture("wsman/timed_out_fault.xml")
+      expected = {:code => "wsman:TimedOut", :reason => "The operation has timed out."}
+      expect(ASM::WsMan.parse(content)).to eq(expected)
+    end
+
+    it "should parse xsi:nil elements" do
+      content = SpecHelper.load_fixture("wsman/osd_concrete_job.xml")
+      expected = {:delete_on_completion => "false",
+                  :instance_id => "DCIM_OSDConcreteJob:1",
+                  :job_name => "BootToNetworkISO",
+                  :job_status => "Rebooting to ISO",
+                  :message => nil,
+                  :message_id => nil,
+                  :name => "BootToNetworkISO"}
+      expect(ASM::WsMan.parse(content)).to eq(expected)
+    end
+  end
+
+  describe "#deployment_invoke" do
+    it "should invoke invoke and parse the command" do
+      expected = {:return_value => "0", :foo => "foo"}
+      ASM::WsMan.expects(:invoke).with(endpoint, "RspecCommand", ASM::WsMan::DEPLOYMENT_SERVICE_SCHEMA, :logger => logger).returns("<rspec />")
+      ASM::WsMan.expects(:parse).with("<rspec />").returns(expected)
+      expect(ASM::WsMan.deployment_invoke(endpoint, "RspecCommand", :logger => logger)).to eq(expected)
+    end
+
+    it "should fail if the ReturnValue does not match" do
+      expected = {:return_value => "2", :message => "Stuff broke"}
+      ASM::WsMan.expects(:invoke).with(endpoint, "RspecCommand", ASM::WsMan::DEPLOYMENT_SERVICE_SCHEMA, :logger => logger).returns("<rspec />")
+      ASM::WsMan.expects(:parse).with("<rspec />").returns(expected)
       expect do
-        ASM::WsMan.boot_to_network_iso(endpoint, "rspec-ip", logger, "rspec-microkernel.iso", "/var/rspec")
-      end.to raise_error("Could not attach network ISO. Error code: FAIL")
+        ASM::WsMan.deployment_invoke(endpoint, "RspecCommand", :return_value => "0", :logger => logger)
+      end.to raise_error("RspecCommand failed: Stuff broke [return_value: 2]")
+    end
+  end
+
+  describe "#detach_iso_image" do
+    it "should invoke DetachISOImage" do
+      ASM::WsMan.expects(:deployment_invoke).with(endpoint, "DetachISOImage", :return_value => "0", :logger => logger)
+      ASM::WsMan.detach_iso_image(endpoint, :logger => logger)
+    end
+  end
+
+  describe "#disconnect_network_iso_image" do
+    it "should invoke DisconnectNetworkISOImage" do
+      ASM::WsMan.expects(:deployment_invoke).with(endpoint, "DisconnectNetworkISOImage", :return_value => "0", :logger => logger)
+      ASM::WsMan.disconnect_network_iso_image(endpoint, :logger => logger)
+    end
+  end
+
+  describe "#get_attach_status" do
+    it "should invoke GetAttachStatus" do
+      ASM::WsMan.expects(:deployment_invoke).with(endpoint, "GetAttachStatus", :logger => logger)
+      ASM::WsMan.get_attach_status(endpoint, :logger => logger)
+    end
+  end
+
+  describe "#get_deployment_job" do
+    it "should get the job id" do
+      job_id = "RspecJob:1"
+      url = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_OSDConcreteJob?InstanceID=%s" % job_id
+      ASM::WsMan.expects(:invoke).with(endpoint, "get", url, :logger => logger).returns("<rspec>")
+      ASM::WsMan.expects(:parse).with("<rspec>").returns(:job_status => "Success")
+      expect(ASM::WsMan.get_deployment_job(endpoint, job_id, :logger => logger)).to eq({:job_status => "Success"})
+    end
+  end
+
+  describe "#camel_case" do
+    it "should not change single word" do
+      expect(ASM::WsMan.camel_case("foo")).to eq("foo")
+    end
+
+    it "should capitalize 2nd word" do
+      expect(ASM::WsMan.camel_case("foo_bar")).to eq("fooBar")
+    end
+
+    it "should capitalize 2nd and greater words" do
+      expect(ASM::WsMan.camel_case("foo_bar_baz")).to eq("fooBarBaz")
+    end
+
+    it "should capitalize first letter if asked" do
+      expect(ASM::WsMan.camel_case("foo_bar", :capitalize => true)).to eq("FooBar")
+    end
+  end
+
+  describe "#snake_case" do
+    it "should not change single word" do
+      expect(ASM::WsMan.snake_case("foo")).to eq("foo")
+    end
+
+    it "should lower-case and add underscore before 2nd word" do
+      expect(ASM::WsMan.snake_case("fooBar")).to eq("foo_bar")
+    end
+
+    it "should lower-case and add underscore before 2nd and greater words" do
+      expect(ASM::WsMan.snake_case("fooBarBaz")).to eq("foo_bar_baz")
+    end
+
+    it "should not begin with an underscore if original did not" do
+      expect(ASM::WsMan.snake_case("ReturnValue")).to eq("return_value")
+    end
+
+    it "should begin with an underscore if original value did" do
+      expect(ASM::WsMan.snake_case("__cimnamespace")).to eq("__cimnamespace")
+    end
+
+    it "should treat multiple capitalized characters as a single word" do
+      expect(ASM::WsMan.snake_case("JobID")).to eq("job_id")
+    end
+
+    it "should handle ISO as a single word" do
+      expect(ASM::WsMan.snake_case("ISOAttachStatus")).to eq("iso_attach_status")
+    end
+
+    it "should handle fcoe and wwnn as single words" do
+      expect(ASM::WsMan.snake_case("FCoEWWNN")).to eq("fcoe_wwnn")
+    end
+
+    it "should handle MAC as a single word" do
+      expect(ASM::WsMan.snake_case("PermanentFCOEMACAddress")).to eq("permanent_fcoe_mac_address")
+    end
+
+  end
+
+  describe "#enum_value" do
+    it "should accept and convert keys to values" do
+      expect(ASM::WsMan.enum_value(:share_type, {:foo => "a", :bar => "b"}, :foo)).to eq("a")
+    end
+
+    it "should accept values" do
+      expect(ASM::WsMan.enum_value(:share_type, {:foo => "a", :bar => "b"}, "b")).to eq("b")
+    end
+
+    it "should accept fixnum " do
+      expect(ASM::WsMan.enum_value(:share_type, {:foo => "a", :bar => "0"}, 0)).to eq("0")
+    end
+
+    it "should fail for unknown values" do
+      expect do
+        ASM::WsMan.enum_value(:share_type, {:foo => "a", :bar => "b"}, :unknown)
+        end.to raise_error("Invalid share_type value: unknown; allowed values are: :foo (a), :bar (b)")
+    end
+  end
+
+  describe "#wsman_value" do
+    it "should convert :share_type" do
+      ASM::WsMan.expects(:enum_value).with(:share_type, {:nfs => "0", :cifs => "2"}, :cifs).returns("2")
+      expect(ASM::WsMan.wsman_value(:share_type, :cifs)).to eq("2")
+    end
+
+    it "should convert :hash_type" do
+      ASM::WsMan.expects(:enum_value).with(:hash_type, {:md5 => "1", :sha1 => "2"}, :md5).returns("1")
+      expect(ASM::WsMan.wsman_value(:hash_type, :md5)).to eq("1")
+    end
+
+    it "should pass through other keys" do
+      expect(ASM::WsMan.wsman_value(:foo, "foo")).to eq("foo")
+    end
+  end
+
+  describe "#run_deployment_job" do
+    let(:options) {{:ip_address => "rspec-ip",
+                    :image_name => "rspec-microkernel.iso",
+                    :share_name => "/var/rspec",
+                    :share_type => :cifs,
+                    :timeout => 60,
+                    :logger => logger}}
+
+    before(:each) do
+      ASM::WsMan.expects(:poll_for_lc_ready).with(endpoint, :logger => logger)
+      ASM::WsMan.expects(:osd_deployment_invoke_iso)
+          .with(endpoint, "BootToNetworkISO", options)
+          .returns({:job => "rspec-job", :job_status => "Started"})
+    end
+
+    it "should poll for LC ready, invoke command and poll job" do
+      ASM::WsMan.expects(:poll_deployment_job).with(endpoint, "rspec-job", options)
+          .returns({:job_status => "Success"})
+      ASM::WsMan.run_deployment_job(endpoint, "BootToNetworkISO", options)
+    end
+
+    it "should fail when job fails" do
+      ASM::WsMan.expects(:poll_deployment_job).with(endpoint, "rspec-job", options)
+          .returns({:job => "rspec-job", :job_status => "Failed"})
+
+      expect do
+        ASM::WsMan.run_deployment_job(endpoint, "BootToNetworkISO", options)
+      end.to raise_error(ASM::WsMan::ResponseError, "BootToNetworkISO job rspec-job failed: Failed [job: rspec-job]")
+    end
+  end
+
+  describe "#connect_network_iso_image" do
+    it "should call run_deployment_job with default timeout of 90 seconds" do
+      ASM::WsMan.expects(:run_deployment_job).with(endpoint, "ConnectNetworkISOImage", {:timeout => 90})
+      ASM::WsMan.connect_network_iso_image(endpoint, {})
+    end
+  end
+
+  describe "#boot to_network_iso_image" do
+    it "should call run_deployment_job with default timeout of 15 minutes" do
+      ASM::WsMan.expects(:run_deployment_job).with(endpoint, "BootToNetworkISO", {:timeout => 15 * 60})
+      ASM::WsMan.boot_to_network_iso_image(endpoint, {})
     end
   end
 end

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,0 +1,4 @@
+desc "Run rubocop style and lint checks"
+task :rubocop do
+  sh("bundle exec rubocop -f progress -f offenses lib")
+end


### PR DESCRIPTION
This PR is more preparation for supporting O/S installs via virtual media mount of ipxe.iso

- add support for DeploymentService ConnectNetworkISOImage, GetAttachStatus and GetNetworkISOConnectionInfo methods.

- add poll_for_lc_ready which will automatically disconnect ISO images. Those connections would block the LC from ever becoming ready. This is an improvement on wait_for_lc_ready.

- add parse method for parsing ws-man responses into ruby-like hashes. Also detects and parses ws-man fault responses.

- add snake_case and camel_case methods to make it easier to accept ws-man invoke command parameters as ruby-style hashes.
