### PR TITLE
ASM-5219 updates to support iPXE ISO boot

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-shell"
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "~>0.35.0"
   s.add_development_dependency "rspec", "~>2.14.0"
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"

--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -281,8 +281,11 @@ module ASM
           missing << card
         else
           nic = nics.delete_at(index)
-          card.interfaces.each do |interface|
-            interface.partitions.each do |partition|
+          card.nic_info = nic
+          card.interfaces.each_with_index do |interface, interface_i|
+            interface.nic_port = nic.ports[interface_i]
+            interface.partitions.each_with_index do |partition, partition_i|
+              partition.nic_view = nic.ports[interface_i].partitions[partition_i]
               partition_no = name_to_partition(partition.name)
               nic_partition = nic.find_partition(name_to_port(interface.name).to_s, partition_no.to_s)
               if nic_partition

--- a/lib/asm/network_configuration/nic_port.rb
+++ b/lib/asm/network_configuration/nic_port.rb
@@ -37,17 +37,14 @@ module ASM
       #
       # @return [Symbol|Void] the vendor or nil if none recognized
       def vendor
-        return :qlogic if nic_view["VendorName"] =~ /qlogic|broadcom/i
-        return :qlogic if nic_view["PCIVendorID"] == "14e4"
-        return :intel if nic_view["VendorName"] =~ /intel/i
-        :intel if nic_view["PCIVendorID"] == "8086" # have seen cases where VendorName not populated
+        nic_view.vendor
       end
 
       # The product name of the NIC port
       #
       # @return [String|Void] the product name or nil if none recognized
       def product
-        nic_view["ProductName"]
+        nic_view.product
       end
 
       # The port number

--- a/lib/asm/network_configuration/nic_view.rb
+++ b/lib/asm/network_configuration/nic_view.rb
@@ -74,6 +74,25 @@ module ASM
         end
       end
 
+      # The vendor for the NIC port
+      #
+      # Currently only :qlogic and :intel vendors are recognized
+      #
+      # @return [Symbol|Void] the vendor or nil if none recognized
+      def vendor
+        return :qlogic if self["VendorName"] =~ /qlogic|broadcom/i
+        return :qlogic if self["PCIVendorID"] == "14e4"
+        return :intel if self["VendorName"] =~ /intel/i
+        :intel if self["PCIVendorID"] == "8086" # have seen cases where VendorName not populated
+      end
+
+      # The product name of the NIC port
+      #
+      # @return [String|Void] the product name or nil if none recognized
+      def product
+        self["ProductName"]
+      end
+
       def card_prefix
         "NIC.%s.%s" % [type, card]
       end

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1078,15 +1078,16 @@ module ASM
 
     # Find the specified boot device in {#boot_source_settings}
     #
-    # @param [Symbol|String] :hdd for "Hard drive C", :virtual_cd for "Virtual Optical Drive" or the device name itself
+    # @param [Symbol|String] :hdd for "Hard drive C", :virtual_cd for "Virtual Optical Drive" or the device FQDD such as
+    #                        HardDisk.List.1-1, Optical.iDRACVirtual.1-1 or NIC.Slot.2-2-1
     # @return [Hash] the boot device, or nil if not found
     # @raise [ResponseError] if a command fails
     def find_boot_device(boot_device)
       boot_settings = boot_source_settings
-      boot_order_map = {:hdd => "Hard drive C", :virtual_cd => "Virtual Optical Drive"}
+      boot_order_map = {:hdd => "HardDisk.List.1-1", :virtual_cd => "Optical.iDRACVirtual.1-1"}
       boot_device = Parser.enum_value("BootDevice", boot_order_map,
                                       boot_device, :strict => false)
-      boot_settings.find { |e| e[:element_name].include?(boot_device) }
+      boot_settings.find { |e| e[:instance_id].include?("#%s#" % boot_device) }
     end
 
     # Set the boot device first in boot order and await completion.

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1059,7 +1059,7 @@ module ASM
                  :reboot_job_type => :graceful_with_forced_shutdown}.merge(options)
       resp = create_targeted_config_job(options)
       logger.info("Initiated BIOS config job %s on %s" % [resp[:job], host])
-      resp = poll_lc_job(resp[:job])
+      resp = poll_lc_job(resp[:job], :timeout => 30 * 60)
       logger.info("Successfully executed BIOS config job %s on %s: %s" % [resp[:job], host, Parser.response_string(resp)])
       logger.info("Waiting for LC ready on %s" % host)
       poll_for_lc_ready

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -39,7 +39,6 @@ describe ASM::NetworkConfiguration do
     end
 
     it "should set interface, partition info on partitions" do
-      net_config.add_partition_info!
       partition_index = 0
       card = net_config.cards.first
       # Verify first interface partitions set correctly
@@ -341,7 +340,7 @@ describe ASM::NetworkConfiguration do
       net_config.add_nics!(Hashie::Mash.new(:host => "127.0.0.1"))
 
       # Verify
-      slot1 = net_config.interfaces[0]
+      slot1 = net_config.cards[0]
       (1..2).each do |port_no|
         port = slot1.interfaces.find { |p| p.name == "Port #{port_no}" }
         (1..4).each do |partition_no|

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -428,7 +428,7 @@ describe ASM::WsMan do
       opts = {:scheduled_start_time => "yyyymmddhhmmss", :reboot_job_type => :power_cycle}
       wsman.expects(:poll_for_lc_ready).twice
       wsman.expects(:create_targeted_config_job).with(opts).returns(:job => "rspec-job")
-      wsman.expects(:poll_lc_job).with("rspec-job").returns(:job => "rspec-job", :job_status => "Success")
+      wsman.expects(:poll_lc_job).with("rspec-job", :timeout => 1800).returns(:job => "rspec-job", :job_status => "Success")
       wsman.run_bios_config_job(opts)
     end
   end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -442,20 +442,14 @@ describe ASM::WsMan do
   end
 
   describe "#find_boot_device" do
-    it "should find boot device by element name" do
-      boot_devices = [{:element_name => "Foo"}]
-      wsman.expects(:boot_source_settings).returns(boot_devices)
-      expect(wsman.find_boot_device("Foo")).to eq(boot_devices.first)
-    end
-
-    it "should find boot device by first part of element_name" do
-      boot_devices = [{:element_name => "Food"}]
+    it "should find boot device by instance_id" do
+      boot_devices = [{:instance_id => "#Foo#"}]
       wsman.expects(:boot_source_settings).returns(boot_devices)
       expect(wsman.find_boot_device("Foo")).to eq(boot_devices.first)
     end
 
     it "should find boot device by :hdd alias" do
-      boot_devices = [{:element_name => "Hard drive C: Boot Device"}]
+      boot_devices = [{:instance_id => "#HardDisk.List.1-1#"}]
       wsman.expects(:boot_source_settings).returns(boot_devices)
       expect(wsman.find_boot_device(:hdd)).to eq(boot_devices.first)
     end


### PR DESCRIPTION
- Add NicView data to the NetworkConfiguration partition data so that it is possible to determine what type of NIC is being used for e.g. the PXE partitions.

- Set boot order based on instance id rather than name. That makes it easy to set a specific NIC in the boot order based on its FQDD.
