### PR TITLE
ASM-5141 capture NIC info in NetworkConfiguration#to_hash

### DIFF
--- a/lib/asm/network_configuration/nic_type.rb
+++ b/lib/asm/network_configuration/nic_type.rb
@@ -52,7 +52,7 @@ module ASM
       end
 
       def to_s
-        "NicType<%s>" % @nictype
+        @nictype
       end
     end
   end


### PR DESCRIPTION
Previously it was just returning the original network_configuration
data that was passed in from the UI. However that ignores the physical
NIC information that is captured when #add_nics! is called such as
FQDD and mac address. We would like to capture that data so that the
network configuration can be passed to razor ERB templates and used to
find out which NICs should be used for PXE boot.