### PR TITLE
ASM-5660 strip out NicInfo in NetworkConfiguration#to_hash

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -374,8 +374,9 @@ module ASM
 
       # Get the ethernet data sans complex types like NicView and NicPort
       cards.each do |card|
-        card["nictype"] = card["nictype"].to_s # convert back to string like 2x10Gb
         card_data = card.to_hash
+        card_data["nictype"] = card_data["nictype"].to_s # convert back to string like 2x10Gb
+        card_data.delete("nic_info") # remove NicInfo instance
         card_data["interfaces"].each do |port|
           port.delete("nic_port") # remove NicPort instance
           port["partitions"].each do |partition|

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -824,6 +824,8 @@ describe ASM::NetworkConfiguration do
     it "should populate fqdd and mac_address in the #to_hash output" do
       hash_data = net_config.to_hash
       card = hash_data["interfaces"].first
+      expect(card["nic_info"]).to be_nil
+      expect(card["nictype"]).to eq("2x10Gb")
 
       # Verify mac_address and fqdd info has been captured in to_hash output
       # and that the complex types NicPort and NicView have been stripped out
@@ -840,6 +842,8 @@ describe ASM::NetworkConfiguration do
       end
 
       card = net_config.cards.first
+      expect(card.nic_info).to be_a(ASM::NetworkConfiguration::NicInfo)
+      expect(card.nictype).to be_a(ASM::NetworkConfiguration::NicType)
 
       # Verify nic_view and nic_port still exist in #cards data
       (1..2).each do |port_no|


### PR DESCRIPTION
Complex types were mistakenly being returned from #to_hash after
recent changes resulting in broken puppet yaml data in some cases.