### PR TITLE
misc: Fix get_network_iso_image_connection_info

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -672,7 +672,7 @@ module ASM
     #    :ipaddr=>"172.25.3.100", :iso_connection_status=>"1",
     #    :image_name=>"ipxe.iso", :return_value=>"0", :share_name=>"/var/nfs"}
     def get_network_iso_image_connection_info # rubocop:disable Style/AccessorMethodName
-      client.invoke("GetNetworkISOConnectionInfo", DEPLOYMENT_SERVICE)
+      client.invoke("GetNetworkISOImageConnectionInfo", DEPLOYMENT_SERVICE)
     end
 
     # Set BIOS attribute values

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -179,8 +179,8 @@ describe ASM::WsMan do
   end
 
   describe "#get_network_iso_image_connection_info" do
-    it "should invoke GetNetworkISOConnectionInfo" do
-      client.expects(:invoke).with("GetNetworkISOConnectionInfo", ASM::WsMan::DEPLOYMENT_SERVICE).returns("rspec-result")
+    it "should invoke GetNetworkISOImageConnectionInfo" do
+      client.expects(:invoke).with("GetNetworkISOImageConnectionInfo", ASM::WsMan::DEPLOYMENT_SERVICE).returns("rspec-result")
       expect(wsman.get_network_iso_image_connection_info).to eq("rspec-result")
     end
   end


### PR DESCRIPTION
The WS-Man command name was wrong. This method is not used by current
ASM workflows so it wasn't causing failures, but good to fix.