### PR TITLE
ASM-5815 Handle mezzanine card fabrics properly

### DIFF
--- a/spec/fixtures/network_configuration/fab_b_fab_c_nic_view.xml
+++ b/spec/fixtures/network_configuration/fab_b_fab_c_nic_view.xml
@@ -1,0 +1,1038 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:bcdd707e-2b6a-1b6a-8002-246faa565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:09c997fb-2b6b-1b6b-b8ff-37bdfffdb624</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsen:EnumerationContext>09c051eb-2b6b-1b6b-b8fe-37bdfffdb624</wsen:EnumerationContext>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_NICView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:bcee5b9d-2b6a-1b6a-8003-246faa565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:09d0b7b4-2b6b-1b6b-b900-37bdfffdb624</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:PullResponse>
+      <wsen:Items>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:10</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 1 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-1-1</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>80</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:10</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:11</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:10</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:11</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:11</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:11</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:11</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:14</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 1 Partition 2</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-1-2</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>2</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-1-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:14</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:15</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:14</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:15</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:15</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:15</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:15</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:18</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 1 Partition 3</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-1-3</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>4</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-1-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:18</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:19</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:18</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:19</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:19</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:19</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:19</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:1C</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 1 Partition 4</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-1-4</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>6</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-1-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:1C</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:1D</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:1C</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:1D</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:1D</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:1D</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:1D</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:12</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 2 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-2-1</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>80</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:12</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:13</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:12</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:13</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:13</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:13</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:13</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:16</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 2 Partition 2</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-2-2</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>3</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-2-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:16</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:17</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:16</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:17</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:17</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:17</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:17</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:1A</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 2 Partition 3</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-2-3</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>5</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-2-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:1A</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:1B</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:1A</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:1B</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:1B</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:1B</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:1B</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>0</n1:AutoNegotiation>
+          <n1:BusNumber>2</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>00:10:18:C3:CF:1E</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Mezzanine 1 Port 2 Partition 4</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Mezzanine.1C-2-4</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>7</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1C-2-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150911004423.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150907214106.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>1</n1:MaxBandwidth>
+          <n1:MediaType>KX4</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1007</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>14e4</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>00:10:18:C3:CF:1E</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>00:10:18:C3:CF:1F</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 00:10:18:C3:CF:1E</n1:ProductName>
+          <n1:ReceiveFlowControl>0</n1:ReceiveFlowControl>
+          <n1:SlotLength>0001</n1:SlotLength>
+          <n1:SlotType>00B5</n1:SlotType>
+          <n1:TransmitFlowControl>0</n1:TransmitFlowControl>
+          <n1:VendorName xsi:nil="true"/>
+          <n1:VirtWWN>20:00:00:10:18:C3:CF:1F</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:00:10:18:C3:CF:1F</n1:VirtWWPN>
+          <n1:WWN>20:00:00:10:18:C3:CF:1F</n1:WWN>
+          <n1:WWPN>20:01:00:10:18:C3:CF:1F</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:C1</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-1</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:C1</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:C2</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:C1</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:C2</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:C2</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:C2</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:C2</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:C5</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 2</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-2</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>2</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:C5</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:C6</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:C5</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:C6</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:C6</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:C6</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:C6</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:C9</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 3</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-3</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>4</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:C9</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:CA</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:C9</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:CA</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:CA</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:CA</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:CA</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:CD</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 4</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-4</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>6</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:CD</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:CE</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:CD</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:CE</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:CE</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:CE</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:CE</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-1-1</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-1-2</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-1-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-1-3</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-1-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-1-4</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-1-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-2-1</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-2-2</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-2-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-2-3</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-2-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>0</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress/>
+          <n1:DataBusWidth/>
+          <n1:DeviceDescription>Unknown</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Mezzanine.1B-2-4</n1:FQDD>
+          <n1:FamilyVersion xsi:nil="true"/>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Mezzanine.1B-2-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>19700101000000.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>19700101000000.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID/>
+          <n1:PCISubDeviceID/>
+          <n1:PCISubVendorID/>
+          <n1:PCIVendorID/>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress/>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>QLogic 57810 10 Gigabit Ethernet</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength/>
+          <n1:SlotType/>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:C3</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-1</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:C3</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:C4</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:C3</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:C4</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:C4</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:C4</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:C4</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:C7</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 2</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-2</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>3</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-2</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:C7</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:C8</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:C7</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:C8</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:C8</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:C8</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:C8</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:CB</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 3</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-3</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>5</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-3</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:CB</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:CC</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:CB</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:CC</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:CC</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:CC</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:CC</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion>7.12.4</n1:ControllerBIOSVersion>
+          <n1:CurrentMACAddress>24:B6:FD:FE:F7:CF</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 4</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.12.19</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>00:00:00:00:00:00</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-4</n1:FQDD>
+          <n1:FamilyVersion>7.12.17</n1:FamilyVersion>
+          <n1:FunctionNumber>7</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-4</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150925214218.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150925224211.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>KR,KX</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>16AE</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>052a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>14e4</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>00:00:00:00:00:00</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:B6:FD:FE:F7:CF</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress>24:B6:FD:FE:F7:D0</n1:PermanentiSCSIMACAddress>
+          <n1:ProductName>QLogic 577xx/578xx 10 Gb Ethernet BCM57810 - 24:B6:FD:FE:F7:CF</n1:ProductName>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>QLogic</n1:VendorName>
+          <n1:VirtWWN>20:00:24:B6:FD:FE:F7:D0</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:B6:FD:FE:F7:D0</n1:VirtWWPN>
+          <n1:WWN>24:B6:24:B6:FD:FE:F7:D0</n1:WWN>
+          <n1:WWPN>20:01:24:B6:FD:FE:F7:D0</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+      </wsen:Items>
+      <wsen:EndOfSequence/>
+    </wsen:PullResponse>
+  </s:Body>
+</s:Envelope>


### PR DESCRIPTION
The mezzanine fabric was not getting used in NicView comparisons or in
the generated card_prefix. This led to separate mezzanine cards,
e.g. 1B and 1C, appearing to be the same card and causing failures in
NicInfo.