### PR TITLE
ASM-5589 Allow using URI string to specify ISO boot location

### DIFF
--- a/lib/asm/ipmi/client.rb
+++ b/lib/asm/ipmi/client.rb
@@ -28,7 +28,6 @@ module ASM
       def augment_logger(logger)
         if !logger.respond_to?(:error) && logger.respond_to?(:err)
           # Puppet logger has most Logger methods, but uses err and warning
-          # rubocop:disable Lint/NestedMethodDefinition
           def logger.error(msg)
             err(msg)
           end
@@ -36,7 +35,6 @@ module ASM
           def logger.warn(msg)
             warning(msg)
           end
-          # rubocop:enable Lint/NestedMethodDefinition
         end
         logger
       end

--- a/lib/asm/wsman/client.rb
+++ b/lib/asm/wsman/client.rb
@@ -28,7 +28,6 @@ module ASM
       def augment_logger(logger)
         if !logger.respond_to?(:error) && logger.respond_to?(:err)
           # Puppet logger has most Logger methods, but uses err and warning
-          # rubocop:disable Lint/NestedMethodDefinition
           def logger.error(msg)
             err(msg)
           end
@@ -36,7 +35,6 @@ module ASM
           def logger.warn(msg)
             warning(msg)
           end
-          # rubocop:enable Lint/NestedMethodDefinition
         end
         logger
       end


### PR DESCRIPTION
URI strings like nfs://hostname/path/to/boot.iso or
smb://hostname/path/to/boot.iso can now be used in the various ISO
connection methods rather than the rather cumbersome individual ws-man
parameters.

Also testing uncovered that ConnectRFSISOImage uses an inconsistent
parameter for username -- :username instead of :user_name. Update that
method to use :username