### PR TITLE
ASM-4774 Add special case for Intel X520/I350 combo card

### DIFF
--- a/lib/asm/network_configuration/nic_port.rb
+++ b/lib/asm/network_configuration/nic_port.rb
@@ -75,6 +75,10 @@ module ASM
         vendor == :qlogic && product =~ /(^|\D)57840(\D|$)/ && n_ports == 4
       end
 
+      def is_intel_x520_i350?
+        vendor == :intel && product =~ /x520\/I350(\D|$)/i && n_ports == 4
+      end
+
       # Whether the NIC port belongs to a 2x10Gb Intel X520 NIC
       #
       # Note that there appear to be many X520 variants. This method only returns
@@ -96,8 +100,8 @@ module ASM
         return "10 Gbps" if is_qlogic_57840?
 
         # Broadcom / QLogic 57800 is a 2x10Gb, 2x1Gb NIC
-        return "10 Gbps" if is_qlogic_57800? && port.between?(1, 2)
-        return "1000 Mbps" if is_qlogic_57800? && port.between?(3, 4)
+        return "10 Gbps" if (is_qlogic_57800? || is_intel_x520_i350?) && port.between?(1, 2)
+        return "1000 Mbps" if (is_qlogic_57800? || is_intel_x520_i350?) && port.between?(3, 4)
 
         return "10 Gbps" if is_intel_x520?
         nil

--- a/spec/fixtures/network_configuration/x520_i350_nic_view.xml
+++ b/spec/fixtures/network_configuration/x520_i350_nic_view.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:6ececafd-2ba9-1ba9-8002-246faa565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:764386e8-2bae-1bae-ace4-016045771814</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsen:EnumerationContext>7641ed69-2bae-1bae-ace3-016045771814</wsen:EnumerationContext>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_NICView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:6edba1c6-2ba9-1ba9-8003-246faa565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:7647caf7-2bae-1bae-ace5-016045771814</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:PullResponse>
+      <wsen:Items>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>6</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:0A:53:04</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 3 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>6.9.7</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-3-1</n1:FQDD>
+          <n1:FamilyVersion>17.0.12</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-3-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160203065057.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160201194043.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>3</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>Base T</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f73</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:0A:53:04</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P X520/I350 rNDC - 24:6E:96:0A:53:04</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>6</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:0A:53:05</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 4 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>6.9.7</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-4-1</n1:FQDD>
+          <n1:FamilyVersion>17.0.12</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-4-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160203065057.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160201194043.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>3</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>Base T</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f73</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:0A:53:05</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P X520/I350 rNDC - 24:6E:96:0A:53:05</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:0A:53:00</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>5.0.16</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>24:6e:96:0a:53:01</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-1</n1:FQDD>
+          <n1:FamilyVersion>17.0.12</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160212102625.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160212102616.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>SFP_PLUS</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>10fb</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f72</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:0A:53:00</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G 4P X520/I350 rNDC - 24:6E:96:0A:53:00</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN>20:00:24:6E:96:0A:53:01</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:6E:96:0A:53:01</n1:VirtWWPN>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN>20:00:24:6E:96:0A:53:01</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:0A:53:02</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>5.0.16</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>24:6e:96:0a:53:03</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-1</n1:FQDD>
+          <n1:FamilyVersion>17.0.12</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160212102625.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160212102616.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>SFP_PLUS</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>10fb</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f72</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:0A:53:02</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G 4P X520/I350 rNDC - 24:6E:96:0A:53:02</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN>20:00:24:6E:96:0A:53:03</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:24:6E:96:0A:53:03</n1:VirtWWPN>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN>20:00:24:6E:96:0A:53:03</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>130</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>A0:36:9F:55:7F:74</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Slot 4 Port 1 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>a0:36:9f:55:7f:75</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Slot.4-1-1</n1:FQDD>
+          <n1:FamilyVersion>16.0.22</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Slot.4-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160212102625.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160212102616.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>SFP_PLUS</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>154d</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>7b11</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>8086</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>A0:36:9F:55:7F:74</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G 2P X520 Adapter - A0:36:9F:55:7F:74</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0004</n1:SlotLength>
+          <n1:SlotType>00B6</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN>20:00:A0:36:9F:55:7F:75</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:A0:36:9F:55:7F:75</n1:VirtWWPN>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN>20:00:A0:36:9F:55:7F:75</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>130</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>A0:36:9F:55:7F:76</n1:CurrentMACAddress>
+          <n1:DataBusWidth>000B</n1:DataBusWidth>
+          <n1:DeviceDescription>NIC in Slot 4 Port 2 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>a0:36:9f:55:7f:77</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Slot.4-2-1</n1:FQDD>
+          <n1:FamilyVersion>16.0.22</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Slot.4-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20160212102625.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20160212102616.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>5</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>SFP_PLUS</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>154d</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>7b11</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>8086</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>A0:36:9F:55:7F:76</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G 2P X520 Adapter - A0:36:9F:55:7F:76</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0004</n1:SlotLength>
+          <n1:SlotType>00B6</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN>20:00:A0:36:9F:55:7F:77</n1:VirtWWN>
+          <n1:VirtWWPN>20:01:A0:36:9F:55:7F:77</n1:VirtWWPN>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN>20:00:A0:36:9F:55:7F:77</n1:WWPN>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+      </wsen:Items>
+      <wsen:EndOfSequence/>
+    </wsen:PullResponse>
+  </s:Body>
+</s:Envelope>

--- a/spec/unit/asm/network_configuration/nic_info_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_info_spec.rb
@@ -58,6 +58,34 @@ describe ASM::NetworkConfiguration::NicInfo do
         expect(nic_infos[1].card_prefix).to eq("NIC.Mezzanine.1B")
         expect(nic_infos[2].card_prefix).to eq("NIC.Mezzanine.1C")
       end
+
+      it "should recognize Intel X520/I350 2x10Gb,2x1Gb combo card" do
+        nic_views_xml = SpecHelper.load_fixture("network_configuration/x520_i350_nic_view.xml")
+        ASM::WsMan.expects(:invoke)
+                  .with(endpoint, "enumerate", "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_NICView", :logger => logger)
+                  .returns(nic_views_xml)
+        ASM::WsMan.expects(:get_bios_enumeration).with(endpoint, logger).returns([])
+        nic_infos = ASM::NetworkConfiguration::NicInfo.fetch(endpoint, logger)
+        expect(nic_infos.size).to eq(2)
+        expect(nic_infos[0].nic_type).to eq("2x10Gb,2x1Gb")
+        expect(nic_infos[1].nic_type).to eq("2x10Gb")
+        expect(nic_infos[0].card_prefix).to eq("NIC.Integrated.1")
+        expect(nic_infos[1].card_prefix).to eq("NIC.Slot.4")
+      end
+
+      it "should recognize Intel X520/I350 2x10Gb,2x1Gb combo card without LinkSpeed info" do
+        nic_views_xml = SpecHelper.load_fixture("network_configuration/x520_i350_nic_view.xml").gsub("<n1:LinkSpeed>3</n1:LinkSpeed>", "<n1:LinkSpeed>0</n1:LinkSpeed>")
+        ASM::WsMan.expects(:invoke)
+                  .with(endpoint, "enumerate", "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_NICView", :logger => logger)
+                  .returns(nic_views_xml)
+        ASM::WsMan.expects(:get_bios_enumeration).with(endpoint, logger).returns([])
+        nic_infos = ASM::NetworkConfiguration::NicInfo.fetch(endpoint, logger)
+        expect(nic_infos.size).to eq(2)
+        expect(nic_infos[0].nic_type).to eq("2x10Gb,2x1Gb")
+        expect(nic_infos[1].nic_type).to eq("2x10Gb")
+        expect(nic_infos[0].card_prefix).to eq("NIC.Integrated.1")
+        expect(nic_infos[1].card_prefix).to eq("NIC.Slot.4")
+      end
     end
 
     describe ".create" do

--- a/spec/unit/asm/network_configuration/nic_port_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_port_spec.rb
@@ -50,6 +50,28 @@ describe ASM::NetworkConfiguration::NicPort do
       expect(port.link_speed).to eq("1000 Mbps")
     end
 
+    it "should override Intel X520/I350 LinkSpeed for port to 10Gbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Intel",
+                  "ProductName" => "X520/I350"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new([nic_info], 4, logger)
+      expect(port.link_speed).to eq("10 Gbps")
+    end
+
+    it "should override Intel X520/I350 LinkSpeed for port 3 to 1000 Mbps" do
+      nic_view = {"FQDD" => "NIC.Integrated.1-3-1",
+                  "CurrentMACAddress" => "04:0A:F7:06:88:50",
+                  "PermanentMACAddress" => "04:0A:F7:06:88:50",
+                  "VendorName" => "Intel",
+                  "ProductName" => "X520/I350"}
+      nic_info = ASM::NetworkConfiguration::NicView.new(nic_view)
+      port = ASM::NetworkConfiguration::NicPort.new([nic_info], 4, logger)
+      expect(port.link_speed).to eq("1000 Mbps")
+    end
+
     it "should override Broadcom 57810 LinkSpeed for port 1 of 2-port NIC to 10 Gbps" do
       nic_view = {"FQDD" => "NIC.Integrated.1-1-1",
                   "CurrentMACAddress" => "04:0A:F7:06:88:50",


### PR DESCRIPTION
Recognize the Intel X520/I350 combo card as a 2x10Gb,2x1Gb card even
in the case where LinkSpeed is not provided by the iDrac.

Now that ASM passes the chosen NIC FQDD as part of the
network_configuration data this is not strictly necessary, but it's
nice to keep this code in sync with the supported NICs.