### PR TITLE
ASM-6172 Allow timeout on #run_command_streaming

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -237,9 +237,9 @@ module ASM
 
     # Run cmd by passing it to the shell and stream stdout and stderr
     # to the specified outfile
-    def self.run_command_streaming(cmd, outfile)
+    def self.run_command_streaming(cmd, outfile, timeout=nil)
       File.open(outfile, "a") do |fh|
-        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+        Open3.popen3("#{"timeout #{timeout} " if timeout}#{cmd}") do |stdin, stdout, stderr, wait_thr|
           stdin.close
 
           # Drain stdout
@@ -259,6 +259,7 @@ module ASM
           end
 
           fh.close
+          raise("#{cmd} timed out; output in #{outfile}") if wait_thr.value.exitstatus == 124
           raise("#{cmd} failed; output in #{outfile}") unless wait_thr.value.exitstatus == 0
         end
       end


### PR DESCRIPTION
Allow a timeout (in seconds) to be passed into the method