### PR TITLE
ASM-6175 HyperV cluster configuration failed due to disable_pxe getting timed-out

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1153,7 +1153,7 @@ module ASM
     # @option options [FixNum] :timeout (5 minutes) default timeout
     # @return [Hash]
     def poll_for_lc_ready(options={})
-      options = {:timeout => 5 * 60}.merge(options)
+      options = {:timeout => 10 * 60}.merge(options)
 
       resp = remote_services_api_status
       return if resp[:lcstatus] == "0"


### PR DESCRIPTION
Increasing LC status check timeout from 5 to 10 minutes to ensure we are waiting enough for server's LC status to be ready after reboot / power-on.