### PR TITLE
ASM-6223 Default to 30 minutes for LC ready timeout

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1153,7 +1153,7 @@ module ASM
     # @option options [FixNum] :timeout (5 minutes) default timeout
     # @return [Hash]
     def poll_for_lc_ready(options={})
-      options = {:timeout => 10 * 60}.merge(options)
+      options = {:timeout => 30 * 60}.merge(options)
 
       resp = remote_services_api_status
       return if resp[:lcstatus] == "0"


### PR DESCRIPTION
This is the default timeout period recommended by the LC team and it
seems like we are still seeing some cases where we time out waiting
for LC ready while disabling PXE boot.