### PR TITLE
ASM-6387 ASM to support Urgent Fury vSAN RA

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"
   s.add_development_dependency "puppetlabs_spec_helper", "0.4.1"
+  s.add_development_dependency "listen", "3.0.7"
 
   s.executables << "wsman_shell.rb"
 

--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", "~> 1.5.10"
   s.add_dependency "i18n", "~> 0.6.5"
   s.add_dependency "pry", "~> 0.10"
+  s.add_development_dependency "listen", "3.0.7"
 
   s.add_development_dependency "logger-colors", "~> 1.0.0"
   s.add_development_dependency "guard-shell"
@@ -24,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"
   s.add_development_dependency "puppetlabs_spec_helper", "0.4.1"
-  s.add_development_dependency "listen", "3.0.7"
 
   s.executables << "wsman_shell.rb"
 

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -19,7 +19,7 @@ module ASM
     POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem,Name=srv:system".freeze
     POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem,SystemName=systemmc,CreationClassName=DCIM_CSPowerManagementService,Name=pwrmgtsvc:1".freeze
     SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate".freeze
-    IDRAC_CARD_ENUMERATION  = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState".freeze
+    IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState".freeze
     APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_iDRACCardService,SystemName=DCIM:ComputerSystem,Name=DCIM:iDRACCardService".freeze
 
     # rubocop:enable Metrics/LineLength
@@ -1402,7 +1402,6 @@ module ASM
       else
         request_power_state_change(:PowerState => :reboot)
       end
-
 
       # Wait for virtual cd to show up in boot source settings
       max_sleep = 60

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1398,9 +1398,9 @@ module ASM
 
       # Have to reboot in order for virtual cd to show up in boot source settings
       if power_state == :off
-        request_power_state_change(:PowerState => :on)
+        request_power_state_change(:power_state => :on)
       else
-        request_power_state_change(:PowerState => :reboot)
+        request_power_state_change(:power_state => :reboot)
       end
 
       # Wait for virtual cd to show up in boot source settings

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -19,7 +19,7 @@ module ASM
     POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem,Name=srv:system".freeze
     POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem,SystemName=systemmc,CreationClassName=DCIM_CSPowerManagementService,Name=pwrmgtsvc:1".freeze
     SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate".freeze
-    VIRTUAL_MEDIA_ATTACH_STATUS="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState".freeze
+    VIRTUAL_MEDIA_ATTACH_STATUS = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState".freeze
     APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_iDRACCardService,SystemName=DCIM:ComputerSystem,Name=DCIM:iDRACCardService".freeze
 
     # rubocop:enable Metrics/LineLength
@@ -1003,7 +1003,7 @@ module ASM
     # @option options [Symbol|String] :power_state 1 to 10"
     # @return [Hash]
     # @raise [ResponseError] if the command fails
-    def request_power_state_change(params={}) # rubocop:disable Style/AccessorMethodName
+    def request_power_state_change(params={})
       client.invoke("RequestPowerStateChange", POWER_STATE_CHANGE,
                     :params => params,
                     :required_params => :PowerState,
@@ -1305,8 +1305,9 @@ module ASM
     def set_virtual_media_attach_state
       va = virtual_media_attach_status.find { |x| x[:attribute_display_name] == "Attach State" }
       if va[:current_value] == "Auto-Attach"
-        resp = apply_idrac_attributes(:target => "iDRAC.Embedded.1", :attribute_name => "VirtualConsole.1#AttachState",
-                            :attribute_value => "Attached")
+        resp = apply_idrac_attributes(:target => "iDRAC.Embedded.1",
+                                      :attribute_name => "VirtualConsole.1#AttachState",
+                                      :attribute_value => "Attached")
         logger.info("Initiated Apply iDRAC attributes config job %s on %s" % [resp[:job], host])
         resp = poll_lc_job(resp[:job], :timeout => 30 * 60)
         logger.info("Successfully executed BIOS config job %s on %s: %s" % [resp[:job], host, Parser.response_string(resp)])
@@ -1355,9 +1356,9 @@ module ASM
 
       # Have to reboot in order for virtual cd to show up in boot source settings
       if power_state == :off
-        request_power_state_change(:PowerState => '2')
+        request_power_state_change(:PowerState => "2")
       else
-        request_power_state_change(:PowerState => '10')
+        request_power_state_change(:PowerState => "10")
       end
 
 

--- a/lib/asm/wsman/parser.rb
+++ b/lib/asm/wsman/parser.rb
@@ -142,9 +142,9 @@ module ASM
                            :read_only_and_password_hash => "3"}, value)
         when :requested_state
           enum_value(key, {:on => "2", :off => "3", :reset => "11"}, value)
-          when :power_state
-            enum_value(key, {:on => "2", :reboot => "10"}, value)
-          else
+        when :power_state
+          enum_value(key, {:on => "2", :reboot => "10"}, value)
+        else
           value
         end
       end

--- a/lib/asm/wsman/parser.rb
+++ b/lib/asm/wsman/parser.rb
@@ -142,7 +142,9 @@ module ASM
                            :read_only_and_password_hash => "3"}, value)
         when :requested_state
           enum_value(key, {:on => "2", :off => "3", :reset => "11"}, value)
-        else
+          when :power_state
+            enum_value(key, {:on => "2", :reboot => "10"}, value)
+          else
           value
         end
       end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -453,7 +453,6 @@ describe ASM::WsMan do
     end
   end
 
-
   describe "#request_power_state_change" do
     it "should invoke RequestStateChange" do
       client.expects(:invoke).with("RequestPowerStateChange", ASM::WsMan::POWER_STATE_CHANGE,
@@ -649,21 +648,24 @@ describe ASM::WsMan do
     let(:opts) {{:scheduled_start_time => "yyyymmddhhmmss", :reboot_job_type => :power_cycle}}
 
     it "should set virtual media to attached mode when current state is Auto-Attach" do
-      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name=>"Attach State",:attribute_name=>"AttachState",:current_value=>"Auto-Attach"}])
-      wsman.expects(:poll_lc_job).with('123', :timeout => 30 * 60).returns(:job => '123', :message => "Success")
+      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name => "Attach State",
+                                                       :attribute_name => "AttachState",
+                                                       :current_value => "Auto-Attach"}])
+      wsman.expects(:poll_lc_job).with("123", :timeout => 30 * 60).returns(:job => "123", :message => "Success")
       wsman.expects(:poll_for_lc_ready)
-      wsman.expects(:apply_idrac_attributes).returns(:job => '123')
+      wsman.expects(:apply_idrac_attributes).returns(:job => "123")
       wsman.set_virtual_media_attach_state
     end
 
     it "should skip virtual media to attached mode when current state is Attached" do
-      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name=>"Attach State",:attribute_name=>"AttachState",:current_value=>"Attached"}])
-      wsman.expects(:poll_lc_job).with('123', :timeout => 30 * 60).returns(:job => '123', :message => "Success").never
+      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name => "Attach State",
+                                                       :attribute_name => "AttachState",
+                                                       :current_value => "Attached"}])
+      wsman.expects(:poll_lc_job).with("123", :timeout => 30 * 60).returns(:job => "123", :message => "Success").never
       wsman.expects(:poll_for_lc_ready).never
-      wsman.expects(:apply_idrac_attributes).returns(:job => '123').never
+      wsman.expects(:apply_idrac_attributes).returns(:job => "123").never
       wsman.set_virtual_media_attach_state
     end
-
   end
 
   describe "#boot_rfs_iso_image" do


### PR DESCRIPTION
As per new recommended flow and Virtual Media needs to be "Attached" state instead of default auto-attach state so that it will always show-up in the device list.
- Execute ConnectRFSISOImage to connect ISO
- Execute PowerStateChange to reboot the host
- Execute GetRemoteServicesAPIStatus, verify LCStatus is Ready
- Execute ChangeBootOrderByInstanceID to set virtual optical as first boot device
- Execute CreateTargetedConfigJob to set the boot order
- Verify config job completes
- Enum DCIM_BootSourceSetting to verify virtual optical is set as first boot device
- Verify system boots to RFS ISO
- Execute DisconnectRFSISOImage to disconnect RFS ISO
- Execute GetRemoteServicesAPIStatus, verify LCStatus is Ready
- Execute ImportSystemConfiguration
- Verify import job completes
- Execute GetRemoteServicesAPIStatus, verify LCStatus is Ready
- Execute ConnectRFSISOImage to connect ISO
- Execute PowerStateChange to reboot the host
- Execute GetRemoteServicesAPIStatus, verify LCStatus is Ready
- Execute ChangeBootOrderByInstanceID to set virtual optical as first boot device
- Execute CreateTargetedConfigJob to set the boot order
- Verify config job completes