### PR TITLE
ASM-6656 Wsman invoke input param

### DIFF
--- a/lib/asm/wsman/client.rb
+++ b/lib/asm/wsman/client.rb
@@ -142,6 +142,7 @@ module ASM
       # @option options [String|Array<String>] :url_params required parameter keys to include in the url
       # @option options [String|Array<String>] :required_params required parameter keys to include as invoke parameters
       # @option options [String|Array<String>] :optional_params optional parameter keys to include as invoke parameters
+      # @option options [String] :input_file path to an xml config file
       # @return [Hash]
       def invoke(method, url, options={})
         params = options.delete(:params) || {}
@@ -168,7 +169,10 @@ module ASM
           url = "%s%s%s" % [url, uri.query ? "&" : "?", encoded_arguments]
         end
 
-        resp = exec(method, url, :props => props)
+        exec_options = {:props => props}
+        exec_options[:input_file] = options[:input_file] if options[:input_file]
+
+        resp = exec(method, url, exec_options)
         ret = Parser.parse(resp)
         if return_value && !Array(return_value).include?(ret[:return_value])
           raise(ASM::WsMan::ResponseError.new("%s failed" % method, ret))

--- a/spec/unit/asm/wsman/client_spec.rb
+++ b/spec/unit/asm/wsman/client_spec.rb
@@ -124,6 +124,12 @@ describe ASM::WsMan::Client do
         .to raise_error(message)
     end
 
+    it "should call exec with input_file if specified" do
+      client.expects(:exec).with("RspecMethod", url, :props => {}, :input_file => "foo").returns("<response />")
+      parser.expects(:parse).with("<response />").returns(:return_value => "0")
+      client.invoke("RspecMethod", url, :input_file => "foo")
+    end
+
     it "should call exec with params and parse the result" do
       client.expects(:exec).with("RspecMethod", url, :props => {"Foo" => "My foo"}).returns("<response />")
       parser.expects(:parse).with("<response />").returns(:return_value => "0")


### PR DESCRIPTION
Allow `:input_file` param to be passed into ASM::WsMan::Client#invoke