### PR TITLE
ASM-6677 Power-off server and razor policy bind/reboot race condition

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1008,6 +1008,13 @@ module ASM
 
       if power_state != :off
         set_power_state(:requested_state => :off)
+        p_state = :on
+        1.upto(10) do
+          sleep 5
+          p_state = power_state
+          break if p_state == :off
+        end
+        raise("Power state not updated to off") if p_state != :off
       else
         logger.debug "Server is already powered off"
       end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -441,9 +441,22 @@ describe ASM::WsMan do
 
   describe "#power_off" do
     it "should power server off if it is on" do
-      wsman.expects(:power_state).returns(:on)
+      wsman.stubs(:power_state).returns(:on, :off)
       wsman.expects(:set_power_state).with(:requested_state => :off)
       wsman.power_off
+    end
+
+    it "should retry power server off if it is still on" do
+      wsman.stubs(:power_state).returns(:on, :on, :off)
+      wsman.expects(:set_power_state).with(:requested_state => :off)
+      wsman.power_off
+    end
+
+    it "should raise error if when power state is not off after multiple retry" do
+      wsman.stubs(:power_state).returns(:on, :on, :on, :on, :on)
+      wsman.expects(:set_power_state).with(:requested_state => :off)
+      message = "Power state not updated to off"
+      expect {wsman.power_off}.to raise_error(message)
     end
 
     it "should do nothing if it is already off" do


### PR DESCRIPTION
Added power status check and retry of the status check to ensure server is powered off before success status is returned.