### PR TITLE
ASM-6558-iDrac 2.40.40.40 requires TLS 1.2 by default

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -11,13 +11,13 @@ require "uri"
 module ASM
   class WsMan
     # rubocop:disable Metrics/LineLength
-    BIOS_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_BIOSService,SystemName=DCIM:ComputerSystem,Name=DCIM:BIOSService".freeze
-    DEPLOYMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_OSDeploymentService,SystemName=DCIM:ComputerSystem,Name=DCIM:OSDeploymentService".freeze
-    JOB_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_JobService?CreationClassName=DCIM_JobService,Name=JobService,SystemName=Idrac,SystemCreationClassName=DCIM_ComputerSystem".freeze
-    LC_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_LCService,SystemName=DCIM:ComputerSystem,Name=DCIM:LCService".freeze
+    BIOS_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_BIOSService&SystemName=DCIM:ComputerSystem&Name=DCIM:BIOSService".freeze
+    DEPLOYMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_OSDeploymentService&SystemName=DCIM:ComputerSystem&Name=DCIM:OSDeploymentService".freeze
+    JOB_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_JobService?CreationClassName=DCIM_JobService&Name=JobService&SystemName=Idrac&SystemCreationClassName=DCIM_ComputerSystem".freeze
+    LC_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_LCService&SystemName=DCIM:ComputerSystem&Name=DCIM:LCService".freeze
     LC_RECORD_LOG_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_LCRecordLog?__cimnamespace=root/dcim".freeze
-    POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem,Name=srv:system".freeze
-    SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate".freeze
+    POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem&Name=srv:system".freeze
+    SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate".freeze
     # rubocop:enable Metrics/LineLength
 
     attr_reader :client

--- a/lib/asm/wsman/client.rb
+++ b/lib/asm/wsman/client.rb
@@ -105,7 +105,7 @@ module ASM
               sleep 10
               return exec(method, schema, options)
             end
-            msg = "Connection failed, Couldn't connect to server. Please check IP address credentials for iDrac at #{host}."
+            msg = "Connection failed, Couldn't connect to server. Please check IP address credentials for iDrac at #{host} or you need to upgrade your wsmancli version to 2.6.0 as current wsmancli version is not compatible with this library "
           else
             msg = "Failed to execute wsman command against server #{host}"
           end

--- a/lib/asm/wsman/client.rb
+++ b/lib/asm/wsman/client.rb
@@ -105,7 +105,7 @@ module ASM
               sleep 10
               return exec(method, schema, options)
             end
-            msg = "Connection failed, Couldn't connect to server. Please check IP address credentials for iDrac at #{host} or you need to upgrade your wsmancli version to 2.6.0 as current wsmancli version is not compatible with this library "
+            msg = "Connection failed, you need to upgrade your wsmancli version to 2.6.0 as current wsmancli version is not compatible with this library or Couldn't connect to server. Please check IP address credentials for iDrac at #{host}."
           else
             msg = "Failed to execute wsman command against server #{host}"
           end


### PR DESCRIPTION
Upgrading wsmancli 2.6.0 to support TLS changes in the next idrac firmware 2.40.40.40