### PR TITLE
ASM-6806 Do not fail if missing Attach State

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1363,7 +1363,9 @@ module ASM
       state_string = Parser.enum_value(nil, state_map, state)
 
       va = idrac_card_enumeration.find { |x| x[:attribute_display_name] == "Attach State" }
-      if va[:current_value] != state_string
+      if !va
+        logger.warn("Attach State not found and will not be set for %s; may be an unsupported iDrac firmware" % host)
+      elsif va[:current_value] != state_string
         logger.info("Changing %s Attach State from %s to %s" % [host, va[:attribute_value], state_string])
         resp = apply_idrac_attributes(:target => "iDRAC.Embedded.1",
                                       :attribute_name => "VirtualConsole.1#AttachState",


### PR DESCRIPTION
Recent changes were made to use "Attach" mode instead of "Auto Attach"
for the virtual CD. Attach mode makes the virtual CD remain in the
boot order even if not virtual ISO is attached. It's use is an
optimization as it should reduce the number of reboots required to
boot a virtual RFS ISO. These changes don't seem to be compatible with
idrac firmware version 1.57 as the name and values of the setting in
the idrac card enumeration have changed:

    [2] pry(#<ASM::WsMan>)> idrac_card_enumeration.find { |e| e[:attribute_display_name] == "Attach Mode" }
    => {:attribute_display_name=>"Attach Mode",
     :attribute_name=>"AttachMode",
     :current_value=>"Auto Attach",
     :default_value=>"Auto Attach",
     :dependency=>nil,
     :display_order=>"1232",
     :fqdd=>"iDRAC.Embedded.1",
     :group_display_name=>"Remote File Share",
     :group_id=>"RFS.1",
     :instance_id=>"iDRAC.Embedded.1#RFS.1#AttachMode",
     :is_read_only=>"false",
     :pending_value=>nil,
     :possible_values=>"Auto Attach"}

We expect the setting to be called "Attach State" and the value to be
"Auto-Attach" (not "Auto Attach" as seen above").

As a quick workaround we just do not set attach mode if it doesn't
show up with the name we expect. As mentioned above its use is an
optimization and should be required for booting an RFS ISO to work.