### PR TITLE
ASM-7035 VSAN deployment fails with VSAN partition on back side disk

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1073,6 +1073,10 @@ module ASM
 
       if power_state != :off
         set_power_state(:requested_state => :off)
+        (1..30).each do |wait_counter|
+          break if power_state == :off
+          sleep 10
+        end
       else
         logger.debug "Server is already powered off"
       end

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1065,6 +1065,8 @@ module ASM
 
     # Power the server off.
     #
+    # After executing the power-off operation, check the power-state and returns once server is in power-off state
+    #
     # @return [void]
     # @raise [ResponseError] if the command fails
     def power_off
@@ -1075,6 +1077,7 @@ module ASM
         set_power_state(:requested_state => :off)
         (1..30).each do |wait_counter|
           break if power_state == :off
+          logger.debug "Server is not in power-off state. Retry counter %d" % wait_counter if logger
           sleep 10
         end
       else

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1080,6 +1080,7 @@ module ASM
           logger.debug "Server is not in power-off state. Retry counter %d" % wait_counter if logger
           sleep 10
         end
+        logger.warn "Server is still not powered-off. Check the server console" if power_state != :off
       else
         logger.debug "Server is already powered off"
       end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -439,7 +439,7 @@ describe ASM::WsMan do
 
   describe "#power_off" do
     it "should power server off if it is on" do
-      wsman.expects(:power_state).times(3).returns(:on, :on, :off)
+      wsman.expects(:power_state).times(4).returns(:on, :on, :off, :off)
       wsman.expects(:set_power_state).with(:requested_state => :off)
       wsman.power_off
     end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -439,7 +439,7 @@ describe ASM::WsMan do
 
   describe "#power_off" do
     it "should power server off if it is on" do
-      wsman.expects(:power_state).returns(:on)
+      wsman.expects(:power_state).times(3).returns(:on, :on, :off)
       wsman.expects(:set_power_state).with(:requested_state => :off)
       wsman.power_off
     end


### PR DESCRIPTION
For some servers, power-off operation is taking some time. Added validation loop to ensure server is powered-off when control is moved out of the method