### PR TITLE
ASM-7091 Use correct attribute for attach mode

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1367,16 +1367,16 @@ module ASM
     # @param state [Symbol] :detach, :attach or :auto_attach
     # @return [void]
     def set_virtual_media_attach_state(state) # rubocop:disable Style/AccessorMethodName
-      state_map = {:detached => "Detached", :attached => "Attached", :auto_attach => "Auto-Attach"}
+      state_map = {:detached => "Detached", :attached => "Attached", :auto_attach => "AutoAttach"}
       state_string = Parser.enum_value(nil, state_map, state)
 
-      va = idrac_card_enumeration.find { |x| x[:attribute_display_name] == "Attach State" }
+      va = idrac_card_enumeration.find { |x| x[:attribute_display_name] == "RAC Virtual Media Attached" }
       if !va
         logger.warn("Attach State not found and will not be set for %s; may be an unsupported iDrac firmware" % host)
       elsif va[:current_value] != state_string
         logger.info("Changing %s Attach State from %s to %s" % [host, va[:attribute_value], state_string])
         resp = apply_idrac_attributes(:target => "iDRAC.Embedded.1",
-                                      :attribute_name => "VirtualConsole.1#AttachState",
+                                      :attribute_name => "VirtualMedia.1#Attached",
                                       :attribute_value => state_string)
         logger.info("Initiated Apply iDRAC attributes config job %s on %s" % [resp[:job], host])
         resp = poll_lc_job(resp[:job], :timeout => 30 * 60)

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -658,14 +658,14 @@ describe ASM::WsMan do
     let(:opts) {{:scheduled_start_time => "yyyymmddhhmmss", :reboot_job_type => :power_cycle}}
 
     it "shoud fail on invalid attach state symbols" do
-      msg = "Invalid  value: foobar; allowed values are: :detached (Detached), :attached (Attached), :auto_attach (Auto-Attach)"
+      msg = "Invalid  value: foobar; allowed values are: :detached (Detached), :attached (Attached), :auto_attach (AutoAttach)"
       expect { wsman.set_virtual_media_attach_state(:foobar) }.to raise_error(msg)
     end
 
     it "should change virtual media attach state if not already set correctly" do
-      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name => "Attach State",
-                                                       :attribute_name => "AttachState",
-                                                       :current_value => "Auto-Attach"}])
+      wsman.expects(:idrac_card_enumeration).returns([{:attribute_display_name => "RAC Virtual Media Attached",
+                                                       :attribute_name => "Attached",
+                                                       :current_value => "AutoAttach"}])
       wsman.expects(:poll_lc_job).with("123", :timeout => 30 * 60).returns(:job => "123", :message => "Success")
       wsman.expects(:poll_for_lc_ready)
       wsman.expects(:apply_idrac_attributes).returns(:job => "123")


### PR DESCRIPTION
The original code for setting attach mode was setting the incorrect
iDrac card enumeration enumeration attribute. This meant that the
server was always left in auto attach mode which requires an
additional reboot in order for the virtual CD to show up in the boot
order list after we attach the ISO. In attach mode the virtual CD is
always present in the boot order list even if no ISO is attached.

In addition to slowing down the install process the additional reboot
was occasionally causing servers to get rebooted while an OS
installation was already in progress and corrupting that install.