### PR TITLE
 misc: fix dependant builds

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", "~> 1.5.10"
   s.add_dependency "i18n", "~> 0.6.5"
   s.add_dependency "pry", "~> 0.10"
+  s.add_dependency("rest-client", "1.8.0")
   s.add_development_dependency "listen", "3.0.7"
 
   s.add_development_dependency "logger-colors", "~> 1.0.0"


### PR DESCRIPTION
Pins restclient to a version that works with our outdated ruby
