### PR TITLE
[maint] Rename has_fc to has_fc?

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -49,14 +49,16 @@ module ASM
     attr_reader(:logger)
     attr_reader(:cards)
     attr_reader(:teams)
-    attr_reader(:has_fc)
 
     def initialize(network_config_hash, logger=nil)
       @logger = logger
       mash = Hashie::Mash.new(network_config_hash)
       @hash = mash.to_hash
-      @has_fc = false
       @cards = build_cards(mash.interfaces)
+    end
+
+    def has_fc?
+      !!@has_fc
     end
 
     def get_wsman_nic_info(endpoint)
@@ -173,6 +175,7 @@ module ASM
       interface_i = 0
       card_i = 0
       cards = []
+      @has_fc = false
 
       interfaces.each do |orig_card|
         # For now we are discarding FC interfaces!

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -27,12 +27,12 @@ describe ASM::NetworkConfiguration do
     let(:net_config1) { ASM::NetworkConfiguration.new(JSON.parse(json1)) }
 
     it "should return true if fc is set" do
-      expect(net_config.has_fc).to eq(true)
+      expect(net_config.has_fc?).to eq(true)
       expect(net_config.cards.size).to be(0)
     end
 
     it "should return true if fc is set" do
-      expect(net_config1.has_fc).to eq(false)
+      expect(net_config1.has_fc?).to eq(false)
       expect(net_config1.cards.size).to be(1)
     end
   end


### PR DESCRIPTION
Generally boolean accessors should end with a question mark