### PR TITLE
ASM-7739 Remove Mssql passwords as well from log

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -323,7 +323,7 @@ module ASM
       ret.each do |key, value|
         if value.is_a?(Hash)
           ret[key] = sanitize(value)
-        elsif key.to_s.downcase.include?("password")
+        elsif key.to_s.downcase =~ /password|pwd/
           ret[key] = "******"
         end
       end


### PR DESCRIPTION
Some of msslq password keys are in the short form
of password ex: SApwd, addition pwd to the condition
such that pwd fields also replaced with *