### PR TITLE
ASM-7884 migrating firmware update utility from Idrac module to util

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 0.6.5"
   s.add_dependency "pry", "~> 0.10"
   s.add_dependency("rest-client", "1.8.0")
+  s.add_dependency "net-ssh", "2.7.0"
   s.add_development_dependency "listen", "3.0.7"
 
   s.add_development_dependency "logger-colors", "~> 1.0.0"

--- a/lib/asm/transport/racadm.rb
+++ b/lib/asm/transport/racadm.rb
@@ -1,0 +1,39 @@
+require "net/ssh"
+
+module ASM
+  class Transport
+    class IdracResetError < StandardError; end
+    class Racadm
+      attr_reader :endpoint, :logger
+
+      def initialize(endpoint, log)
+        @logger = log
+        @endpoint = endpoint
+      end
+
+      # Used to reset iDRAC
+      #
+      # @return [void]
+      # @raise [StandardError] the resulting would unable to establish ssh connection or racadm command fails
+      def reset_idrac
+        logger.debug("Resetting iDrac...")
+        Net::SSH.start(@endpoint[:host],
+                       @endpoint[:user],
+                       :password => @endpoint[:pass],
+                       :paranoid => Net::SSH::Verifiers::Null.new,
+                       :global_known_hosts_file => "/dev/null") do |ssh|
+          ssh.exec!("racadm racreset soft") do |_, stream, data|
+            logger.debug(data)
+
+            if data.include? "Could not chdir to home directory"
+              logger.debug("Warning for message is %s" % data)
+            elsif stream == :stderr
+              raise IdracResetError
+            end
+          end
+          ssh.close
+        end
+      end
+    end
+  end
+end

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -538,6 +538,17 @@ module ASM
                     :return_value => "4096")
     end
 
+    # Parse the specified XML generated schema
+    #
+    # @params options [Hash] the options to install specified config file path
+    # @example
+    #      :input_file => "/tmp/xml_parsed_path"
+    # @return [Hash]
+    # @raise [ResponseError] if command fails
+    def install_from_uri(options={})
+      client.invoke("InstallFromURI", SOFTWARE_INSTALLATION_SERVICE, :input_file => options[:input_file])
+    end
+
     # Set up a job queue with jobs to execute
     #
     # This method is used for creating a job queue that shall contain one or more

--- a/spec/unit/asm/firmware_spec.rb
+++ b/spec/unit/asm/firmware_spec.rb
@@ -1,0 +1,268 @@
+require "spec_helper"
+require "asm/firmware"
+
+describe ASM::Firmware do
+  let(:logger) { stub(:debug => nil, :warn => nil, :info => nil) }
+  let(:endpoint) { {:host => "rspec-host", :user => "rspec-user", :password => "rspec-password"} }
+  let(:wsman) { mock("wsman") }
+  let(:cred) { {:host => "rspec-host", :user => "rspec-user", :password => "rspec-password"} }
+  let(:firmware) { mock("firmware") }
+
+  let(:firmware_obj) { ASM::Firmware.new(endpoint, :logger => logger) }
+
+  let(:config) do
+    {"asm::server_update" =>
+         {"rackserver-5xclw12" =>
+              {"asm_hostname" => "172.25.5.100",
+               "path" => "/var/nfs/firmware/ff808081578bd88601578d525d4e004e/ASMCatalog.xml",
+               "server_firmware" => "Firmware_path"
+              }
+         }
+    }
+  end
+
+  let(:resource_hash) do
+    [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+      "uri_path" => "rspec-nfs-path"
+     },
+     {"instance_id" => "DCIM:INSTALLED#iDRAC.Embedded.1-1#IDRACinfo",
+      "component_id" => "25227",
+      "uri_path" => "rspec-nfs-path"
+     }
+    ]
+  end
+
+  let(:resource_hash2) do
+    [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+      "uri_path" => "rspec-nfs-path"
+     },
+     {"instance_id" => "DCIM:INSTALLED#701__NIC.Embedded.1-1-1",
+      "uri_path" => "rspec-nfs-path"
+     }
+    ]
+  end
+
+  let(:device_config) do
+    {"cert_name" => "rackserver-5xclw12",
+     "host" => "rspec-host",
+     "port" => nil,
+     "path" => "/asm/bin/idrac-discovery.rb",
+     "scheme" => "script",
+     "arguments" => {"credential_id" => "ff80808157bfd05a0157bfd13392000d"},
+     "user" => "rspec-user",
+     "enc_password" => nil,
+     "password" => "rspec-password"
+    }
+  end
+
+  let(:firmware_list) do
+    [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+     }
+    ]
+  end
+  let(:firmware_list2) do
+    [{"instance_id" => "DCIM:INSTALLED#701__NIC.Embedded.1-1-1",
+      "uri_path" => "nfs://172.25.5.100/FOLDER03287319M/3/Network_Firmware_0MT4K_WN64_7.10.64.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+     }
+    ]
+  end
+  let(:status) do
+    {"JID_767739984470" =>
+         {:job_id => "JID_767739984470",
+          :status => "new",
+          :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+                        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+                       },
+          :start_time => Time.now
+         }
+    }
+  end
+
+  let(:status2) do
+    {"JID_767739984470" =>
+         {:job_id => "JID_767739984470",
+          :status => "Scheduled",
+          :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+                        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+                       },
+          :start_time => Time.now
+         }
+    }
+  end
+
+  let(:status3) do
+    {"JID_123" =>
+       {:job_id => "JID_123",
+        :status => "Completed",
+        :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+                      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+                     },
+        :start_time => Time.now
+       }
+    }
+  end
+
+  let(:status4) do
+    {"JID_767739984470" =>
+       {:job_id => "JID_767739984470",
+        :status => "new",
+        :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+                      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+                     },
+        :start_time => Time.now,
+        :reboot_required => true,
+        :desired => "Scheduled"
+       }
+    }
+  end
+
+  describe "#idrac_fw_install_from_uri" do
+    before do
+      ASM::WsMan.stubs(:new).with(endpoint, :logger => logger).returns(wsman)
+      ASM::Firmware.stubs(:new).with(endpoint, :logger => logger).returns(firmware)
+    end
+
+    it "should raise an error when empty resources found" do
+      expect { ASM::Firmware.idrac_fw_install_from_uri("123", nil, "rspec-device-config", logger) }.to raise_error("Received empty resources to update the firmware on server")
+    end
+
+    it "should upate the firmware" do
+      firmware_obj.expects(:clear_job_queue_retry).with(wsman).returns(nil)
+      firmware_obj.expects(:update_idrac_firmware).returns(nil).twice
+      wsman.expects(:poll_for_lc_ready)
+      ASM::Firmware.idrac_fw_install_from_uri(config, resource_hash, device_config, logger)
+    end
+
+    it "should update the firmware once" do
+      firmware.expects(:clear_job_queue_retry).with(wsman).returns(nil)
+      firmware.expects(:update_idrac_firmware).returns(nil).once
+      wsman.expects(:poll_for_lc_ready)
+      ASM::Firmware.idrac_fw_install_from_uri(config, resource_hash2, device_config, logger)
+    end
+  end
+
+  describe "#clear_job_queue_retry" do
+    let(:response) { {:return_value => "0"} }
+    let(:response2) { {:return_value => "1"} }
+    let(:logger) { stub(:debug => nil, :warn => nil, :info => nil) }
+    let(:endpoint) { {:host => "rspec-host", :user => "rspec-user", :password => "rspec-password"} }
+    let(:transport) { mock("transport") }
+
+    before(:each) do
+      ASM::WsMan.stubs(:new).with(endpoint, :logger => logger).returns(wsman)
+    end
+
+    it "should clear the job queue successfully" do
+      wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").returns(response)
+      wsman.expects(:poll_for_lc_ready)
+      firmware_obj.clear_job_queue_retry(wsman)
+    end
+
+    it "should try up to 3 times" do
+      mock_transport = mock("mock transport")
+      mock_transport.expects(:reset_idrac).twice
+      firmware_obj.stubs(:sleep).with(60).returns(nil)
+      wsman.expects(:poll_for_lc_ready)
+      ASM::WsMan::Client.stubs(:endpoint).returns(endpoint)
+      ASM::Transport::Racadm.expects(:new).with(endpoint, logger).returns(mock_transport).times(2)
+      wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").times(3).returns(response2, response2, response)
+      firmware_obj.clear_job_queue_retry(wsman)
+    end
+
+    it "should fail after trying three times" do
+      mock_transport = mock("mock transport")
+      mock_transport.expects(:reset_idrac).twice
+      firmware_obj.stubs(:sleep).with(60).returns(nil)
+      ASM::WsMan::Client.stubs(:endpoint).returns(endpoint)
+      ASM::Transport::Racadm.expects(:new).with(endpoint, logger).returns(mock_transport).times(2)
+      wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").returns(response2).times(3)
+      expect do
+        firmware_obj.clear_job_queue_retry(wsman)
+      end.to raise_error("Unable to find the LC status after clearing job queue")
+    end
+  end
+
+  describe "#update_idrac_firmware" do
+    it "should update the firmware" do
+      firmware_obj.stubs(:gets_install_uri_job).returns("JID_767739984470")
+      firmware_obj.stubs(:block_until_downloaded).returns(status2)
+      firmware_obj.stubs(:schedule_reboot_job_queue).returns(nil)
+      Time.stubs(:now).returns(status["JID_767739984470"][:start_time])
+      firmware_obj.stubs(:sleep)
+      wsman.stubs(:get_lc_job).with("JID_767739984470").returns("Completed")
+      firmware_obj.update_idrac_firmware(firmware_list, false, wsman)
+    end
+
+    it "Internal Timeout while Error while updating the firmware" do
+      firmware_obj.stubs(:gets_install_uri_job).returns("JID")
+      firmware_obj.stubs(:block_until_downloaded).returns(status)
+      Time.stubs(:now).returns(status["JID_767739984470"][:start_time] + ASM::Firmware::MAX_WAIT_SECONDS + 1)
+      firmware_obj.stubs(:sleep)
+      firmware_obj.stubs(:schedule_reboot_job_queue).returns(nil)
+      wsman.stubs(:get_lc_job).with("JID_767739984470").returns("Complete")
+      expect do
+        firmware_obj.update_idrac_firmware(firmware_list, false, wsman)
+      end.to raise_error("Firmware update failed in the lifecycle controller. Please refer to LifeCycle job logs")
+    end
+  end
+
+  describe "#gets_install_uri_job" do
+    let(:success_return) do
+      {:job => "123", :return_value => "4096"}
+    end
+    let(:failed_return) do
+      {:job => "123", :return_value => "404", :message => "timedout"}
+    end
+    it "should pass the uri mount path successfully and return job_id" do
+      wsman.stubs(:install_from_uri).returns(success_return)
+      expect(firmware_obj.gets_install_uri_job(firmware_list.first, wsman)).to eq("123")
+    end
+
+    it "should raise an error when install_from_uri job fails" do
+      data = {:name => "xyz", :description => "test file"}.to_json
+      data.stubs(:path).returns("/tmp")
+      data.stubs(:read).returns("tmp")
+      firmware_obj.stubs(:create_xml_config_file).returns(data)
+      wsman.stubs(:install_from_uri).returns(failed_return)
+      expect do
+        firmware_obj.gets_install_uri_job(firmware_list.first, wsman)
+      end.to raise_error("Problem running InstallFromURI: timedout")
+    end
+  end
+
+  describe "#block_until_downloaded" do
+    let(:job_status) { {:job_status => "Scheduled"} }
+    let(:job_status2) { {:job_status => "Completed"} }
+    let(:job_status3) { {:job_status => "Failed"} }
+    it "should update the job status to complete" do
+      firmware_obj.stubs(:sleep)
+      Time.stubs(:now).returns(50)
+      wsman.stubs(:get_lc_job).with("JID_123").returns(job_status2)
+      expect(firmware_obj.block_until_downloaded("JID_123", firmware_list.first, wsman)).to eq(status3)
+    end
+
+    it "should update lc status on second time" do
+      firmware_obj.stubs(:sleep).with(30).returns(nil)
+      Time.stubs(:now).returns(50)
+      wsman.stubs(:get_lc_job).with("JID_123").times(2).returns(job_status, job_status2)
+      expect(firmware_obj.block_until_downloaded("JID_123", firmware_list.first, wsman)).to eq(status3)
+    end
+
+    it "update status should failed" do
+      firmware_obj.stubs(:sleep)
+      wsman.stubs(:get_lc_job).with("JID_123").returns(job_status3)
+      expect do
+        firmware_obj.block_until_downloaded("JID_123", firmware_list.first, wsman)
+      end.to raise_error("Firmware update failed in the lifecycle controller.  Please refer to LifeCycle job logs")
+    end
+
+    it "should raise error after two times" do
+      firmware_obj.stubs(:sleep).with(30).returns(nil)
+      wsman.stubs(:get_lc_job).with("JID_123").times(2).returns(job_status, job_status3)
+      expect do
+        firmware_obj.block_until_downloaded("JID_123", firmware_list.first, wsman)
+      end.to raise_error("Firmware update failed in the lifecycle controller.  Please refer to LifeCycle job logs")
+    end
+  end
+end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -277,6 +277,15 @@ describe ASM::WsMan do
     end
   end
 
+  describe "#install_from_uri" do
+    it "should invoke InstallFromURI" do
+      client.expects(:invoke).with("InstallFromURI",
+                                   ASM::WsMan::SOFTWARE_INSTALLATION_SERVICE,
+                                   :input_file => "/tmp").returns("rspec-result")
+      expect(wsman.install_from_uri(:input_file => "/tmp")).to eq("rspec-result")
+    end
+  end
+
   describe "#delete_job_queue" do
     it "should invoke DeleteJobQueue" do
       client.expects(:invoke).with("DeleteJobQueue", ASM::WsMan::JOB_SERVICE,


### PR DESCRIPTION
migrating firmware update IDRAC module to Util. through which we  can remove possible unnecessary XML config files in IDRAC module , By using only existing wsman commands. 

cautions: 
     Had to include "net/ssh" library to Gem file. 