### PR TITLE
ASM-7905 Utility method - wsman identify command

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1483,6 +1483,36 @@ module ASM
       end
     end
 
+    # Execute identify command
+    #
+    # executes identify command on the server, and returns raw output
+    #
+    # @param timeout [FixNum] command timeout in seconds
+    # @return [Hash] nil if there was a command timeout, otherwise output result
+    # @example response
+    #  {
+    #    :protocol_version=>"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd",
+    #    :product_vendor=>"Dell, Inc.",
+    #    :product_version=>"iDRAC : System Type = 12G Monolithic : LC Version = 2.30.30.30 : Version = 2.30.30.30",
+    #    :smashversion=>"2.0.0",
+    #    :product_name=>"iDRAC",
+    #    :system_generation=>"12G Monolithic",
+    #    :firmware_version=>"2.30.30.30",
+    #    :lifecycle_controller_version=>"2.30.30.30",
+    #    :security_profiles=>"HTTP_TLS_1HTTP_TLS_2"
+    #  }
+    # @raise [ASM::WsMan::Error] when error other than timeout occurs
+    def identify(timeout)
+      response = nil
+      begin
+        response = client.identify(timeout)
+      rescue ASM::WsMan::Error => ex
+        # when identify command errors on timeout, we return nil value to the caller to indicate no identity info
+        raise ex unless ex.message =~ /Timeout/
+      end
+      response
+    end
+
     def self.sleep_time
       60
     end

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -773,4 +773,21 @@ describe ASM::WsMan do
                            ["20:00:00:24:FF:4A:BB:5B", "21:00:00:24:FF:4A:BB:5B"]]
     end
   end
+
+  describe "#identify" do
+    it "should call identify and return nil when error is timeout" do
+      client.expects(:identify).with(10).raises(ASM::WsMan::Error, "Some text\nTimeout reached")
+      expect(wsman.identify(10)).to eq(nil)
+    end
+
+    it "should call identify and raise an error when error is other than timeout" do
+      client.expects(:identify).with(10).raises(ASM::WsMan::Error, "Random error happened")
+      expect {wsman.identify(10)}.to raise_error(ASM::WsMan::Error, "Random error happened")
+    end
+
+    it "should call identify and get valid hash response" do
+      client.expects(:identify).with(10).returns(:product_name => "iDRAC")
+      expect(wsman.identify(10)).to eq(:product_name => "iDRAC")
+    end
+  end
 end


### PR DESCRIPTION
wsman identify command provides quick information about a server, and
can be used for scenarios like waiting on valid IDRAC server when IP
changes.