### PR TITLE
ASM-8201 Update net-ssh dependency

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 0.6.5"
   s.add_dependency "pry", "~> 0.10"
   s.add_dependency("rest-client", "1.8.0")
-  s.add_dependency "net-ssh", "2.7.0"
+  s.add_dependency "net-ssh", "~> 2.7"
   s.add_development_dependency "listen", "3.0.7"
 
   s.add_development_dependency "logger-colors", "~> 1.0.0"


### PR DESCRIPTION
The ASM appliance ships with net-ssh 2.9.4 currently, so updating the
net-ssh gemspec dependency to be compatible with that.