### PR TITLE
ASM-7884, ASM-8182 Firmware updates failing

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -13,7 +13,7 @@ module ASM
     # rubocop:disable Metrics/LineLength
     BIOS_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_BIOSService&SystemName=DCIM:ComputerSystem&Name=DCIM:BIOSService".freeze
     DEPLOYMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_OSDeploymentService&SystemName=DCIM:ComputerSystem&Name=DCIM:OSDeploymentService".freeze
-    JOB_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_JobService?CreationClassName=DCIM_JobService&Name=JobService&SystemName=Idrac&SystemCreationClassName=DCIM_ComputerSystem".freeze
+    JOB_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=DCIM_JobService&Name=JobService&SystemName=Idrac&SystemCreationClassName=DCIM_ComputerSystem&__cimnamespace=root/dcim".freeze
     LC_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_LCService&SystemName=DCIM:ComputerSystem&Name=DCIM:LCService".freeze
     LC_RECORD_LOG_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_LCRecordLog?__cimnamespace=root/dcim".freeze
     POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem&Name=srv:system".freeze
@@ -562,13 +562,19 @@ module ASM
     #                         string "TIME_NOW" means immediate.
     # @option params [String] :until_time End time for the job execution in format: yyyymmddhhmmss. If this
     #                         parameter is not NULL, then StartTimeInterval parameter shall also be specified.
+    # @option params [String] :input_file Path to a configuration input file.  This can not be used with :job_array
     # @return [Hash]
     # @raise [ResponseError] if the command fails
     def setup_job_queue(params={})
-      client.invoke("SetupJobQueue", JOB_SERVICE,
-                    :params => params,
-                    :optional_params => [:job_array, :start_time_interval, :until_time],
-                    :return_value => "0")
+      input_file = params.delete(:input_file)
+      options = {
+        :params => params,
+        :optional_params => [:job_array, :start_time_interval, :until_time],
+        :return_value => "0"
+      }
+      options[:input_file] = input_file if input_file
+
+      client.invoke("SetupJobQueue", JOB_SERVICE, options)
     end
 
     # Delete one or all jobs from the job queue

--- a/spec/unit/asm/firmware_spec.rb
+++ b/spec/unit/asm/firmware_spec.rb
@@ -68,52 +68,52 @@ describe ASM::Firmware do
     ]
   end
   let(:status) do
-    {"JID_767739984470" =>
-         {:job_id => "JID_767739984470",
-          :status => "new",
-          :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-                        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-                       },
-          :start_time => Time.now
-         }
+    {
+      :job_id => "JID_767739984470",
+      :status => "new",
+      :firmware => {
+        "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+      },
+      :start_time => Time.now
     }
   end
 
   let(:status2) do
-    {"JID_767739984470" =>
-         {:job_id => "JID_767739984470",
-          :status => "Scheduled",
-          :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-                        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-                       },
-          :start_time => Time.now
-         }
+    {
+      :job_id => "JID_767739984470",
+      :status => "Scheduled",
+      :firmware => {
+        "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+      },
+      :start_time => Time.now
     }
   end
 
   let(:status3) do
-    {"JID_123" =>
-       {:job_id => "JID_123",
-        :status => "Completed",
-        :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-                      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-                     },
-        :start_time => Time.now
-       }
+    {
+      :job_id => "JID_123",
+      :status => "Completed",
+      :firmware => {
+        "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+      },
+      :start_time => Time.now
     }
   end
 
   let(:status4) do
-    {"JID_767739984470" =>
-       {:job_id => "JID_767739984470",
-        :status => "new",
-        :firmware => {"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-                      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-                     },
-        :start_time => Time.now,
-        :reboot_required => true,
-        :desired => "Scheduled"
-       }
+    {
+      :job_id => "JID_767739984470",
+      :status => "new",
+      :firmware => {
+        "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
+        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+      },
+      :start_time => Time.now,
+      :reboot_required => true,
+      :desired => "Scheduled"
     }
   end
 
@@ -164,7 +164,7 @@ describe ASM::Firmware do
       mock_transport.expects(:reset_idrac).twice
       firmware_obj.stubs(:sleep).with(60).returns(nil)
       wsman.expects(:poll_for_lc_ready)
-      ASM::WsMan::Client.stubs(:endpoint).returns(endpoint)
+      wsman.expects(:client).returns(stub(:endpoint => endpoint)).times(2)
       ASM::Transport::Racadm.expects(:new).with(endpoint, logger).returns(mock_transport).times(2)
       wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").times(3).returns(response2, response2, response)
       firmware_obj.clear_job_queue_retry(wsman)
@@ -174,7 +174,7 @@ describe ASM::Firmware do
       mock_transport = mock("mock transport")
       mock_transport.expects(:reset_idrac).twice
       firmware_obj.stubs(:sleep).with(60).returns(nil)
-      ASM::WsMan::Client.stubs(:endpoint).returns(endpoint)
+      wsman.expects(:client).returns(stub(:endpoint => endpoint)).times(2)
       ASM::Transport::Racadm.expects(:new).with(endpoint, logger).returns(mock_transport).times(2)
       wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").returns(response2).times(3)
       expect do
@@ -188,7 +188,7 @@ describe ASM::Firmware do
       firmware_obj.stubs(:gets_install_uri_job).returns("JID_767739984470")
       firmware_obj.stubs(:block_until_downloaded).returns(status2)
       firmware_obj.stubs(:schedule_reboot_job_queue).returns(nil)
-      Time.stubs(:now).returns(status["JID_767739984470"][:start_time])
+      Time.stubs(:now).returns(status[:start_time])
       firmware_obj.stubs(:sleep)
       wsman.stubs(:get_lc_job).with("JID_767739984470").returns("Completed")
       firmware_obj.update_idrac_firmware(firmware_list, false, wsman)
@@ -197,7 +197,7 @@ describe ASM::Firmware do
     it "Internal Timeout while Error while updating the firmware" do
       firmware_obj.stubs(:gets_install_uri_job).returns("JID")
       firmware_obj.stubs(:block_until_downloaded).returns(status)
-      Time.stubs(:now).returns(status["JID_767739984470"][:start_time] + ASM::Firmware::MAX_WAIT_SECONDS + 1)
+      Time.stubs(:now).returns(status[:start_time] + ASM::Firmware::MAX_WAIT_SECONDS + 1)
       firmware_obj.stubs(:sleep)
       firmware_obj.stubs(:schedule_reboot_job_queue).returns(nil)
       wsman.stubs(:get_lc_job).with("JID_767739984470").returns("Complete")


### PR DESCRIPTION
Fix the firmware update code that was incorrectly ported over from
the idrac puppet module.  This was resulting in the reboot
job and the job queue never being scheduled.

Also, we were incorrectly finishing the job early without checking
all of the statuses