### PR TITLE
ASM-8336 Idrac Reset failing

### DIFF
--- a/lib/asm/transport/racadm.rb
+++ b/lib/asm/transport/racadm.rb
@@ -19,7 +19,7 @@ module ASM
         logger.debug("Resetting iDrac...")
         Net::SSH.start(@endpoint[:host],
                        @endpoint[:user],
-                       :password => @endpoint[:pass],
+                       :password => @endpoint[:password],
                        :paranoid => Net::SSH::Verifiers::Null.new,
                        :global_known_hosts_file => "/dev/null") do |ssh|
           ssh.exec!("racadm racreset soft") do |_, stream, data|


### PR DESCRIPTION
Idrac reset is failing because the ssh connection was expecting
the user to enter a password because we were currently supplying
null for the value