### PR TITLE
ASM-8477 Unity puppet

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", "~> 1.5.10"
   s.add_dependency "i18n", "~> 0.6.5"
   s.add_dependency "pry", "~> 0.10"
-  s.add_dependency("rest-client", "1.8.0")
+  s.add_dependency("rest-client", "<= 1.8.0")
   s.add_dependency "net-ssh", "~> 2.7"
   s.add_development_dependency "listen", "3.0.7"
 


### PR DESCRIPTION
Unity REST calls only works with Rest-client 1.6.7

Rest-client 1.8.0 doesn't work because it has issues
with handling redirection with cookies and headers