### PR TITLE
ASM-8733 Do graceful power offs by default

### DIFF
--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
   s.add_development_dependency "rubocop", "0.37.2"
-  s.add_development_dependency "rspec", "~>2.14.0"
+  s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"
   s.add_development_dependency "puppetlabs_spec_helper", "0.4.1"

--- a/lib/asm/wsman/parser.rb
+++ b/lib/asm/wsman/parser.rb
@@ -141,9 +141,9 @@ module ASM
           enum_value(key, {:default => "0", :read_only => "1", :password_hash => "2",
                            :read_only_and_password_hash => "3"}, value)
         when :requested_state
-          enum_value(key, {:on => "2", :off => "3", :reset => "11"}, value)
+          enum_value(key, {:on => "2", :off => "3", :forced => "8", :reset => "11", :graceful => "12"}, value)
         when :power_state
-          enum_value(key, {:on => "2", :reboot => "10"}, value)
+          enum_value(key, {:power_on => "2", :power_cycle => "3", :power_off => "8", :reset => "10", :diagnostic => "11", :graceful_shutdown => "12"}, value)
         else
           value
         end


### PR DESCRIPTION
In general it's better to do graceful shutdowns than just shutting off
power. There is no straightforward WS-Man method to implement
"graceful with forced" shutdown functionality -- i.e. issuing a
graceful shutdown and then switching off the power at some point if
the OS doesn't respond. This change makes the default
`wsman.power_off` call execute in this manner.

This specifically addresses some cases that were seen when resetting
ESXi management IPs where that command seems to succeed but after
force powering off the server (the previous functionality of
`wsman.power_off`) and then powering it back on that configuration
change was lost.