### PR TITLE
ASM-8652 Fixes for jruby 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ sudo: false
 rvm:
   - 1.9.3
   - jruby-19mode
+  - jruby-9.1.6.0
   - 2.1.9

--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-shell"
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
+  s.add_development_dependency "rainbow", "~> 2.1.0" # for https://github.com/sickill/rainbow/issues/48
   s.add_development_dependency "rubocop", "0.37.2"
   s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "mocha"

--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -128,7 +128,7 @@ module ASM
     # Management Network      vSwitch0                     1        0
     # vMotion                 vSwitch1                     1       23
     def self.esxcli(cmd_array, endpoint, logger=nil, skip_parsing=false, time_out=600)
-      args = [time_out, "env", "VI_PASSWORD=#{endpoint[:password]}", "esxcli"]
+      args = [time_out.to_s, "env", "VI_PASSWORD=#{endpoint[:password]}", "esxcli"]
       args += ["-s", endpoint[:host],
                "-u", endpoint[:user]
               ]


### PR DESCRIPTION
- The timeout command argument was passed as a Fixnum argument to
  Open3.popen3 which fails with "TypeError: no implicit conversion of
  Fixnum into String". Interestingly that fails under ruby 1.9 as
  well, it only seems to work in jruby 1.7

- Pin rainbow to 2.0.x to work around issues with [bundler 0.14 and
  rainbow][1].

[1]: https://github.com/sickill/rainbow/issues/48