### PR TITLE
ASM-9191 let wsman client options adjust exec behaviour

### DIFF
--- a/lib/asm/wsman/client.rb
+++ b/lib/asm/wsman/client.rb
@@ -10,9 +10,19 @@ module ASM
 
       def initialize(endpoint, options={})
         missing_params = [:host, :user, :password].reject { |k| endpoint.include?(k) }
+
         raise("Missing required endpoint parameter(s): %s" % [missing_params.join(", ")]) unless missing_params.empty?
+
         @endpoint = endpoint
         @logger = augment_logger(options.delete(:logger) || Logger.new(nil))
+        @default_options = {
+          :selector => nil,
+          :props => {},
+          :input_file => nil,
+          :nth_attempt => 0,
+          :transport_timeout => 300,
+          :retry_on_error => true
+        }.merge(options)
 
         proxy_warn
       end
@@ -60,14 +70,7 @@ module ASM
       # @return [String]
       # rubocop:disable Metrics/MethodLength
       def exec(method, schema, options={})
-        options = {
-          :selector => nil,
-          :props => {},
-          :input_file => nil,
-          :nth_attempt => 0,
-          :transport_timeout => 300,
-          :retry_on_error => true
-        }.merge(options)
+        options = @default_options.merge(options)
 
         if %w(enumerate get identify).include?(method)
           args = [method]

--- a/spec/unit/asm/wsman/client_spec.rb
+++ b/spec/unit/asm/wsman/client_spec.rb
@@ -35,7 +35,18 @@ describe ASM::WsMan::Client do
     let(:auth_failed_response) {Hashie::Mash.new(:exit_status => 1, :stdout => "Authentication failed", :stderr => "")}
     let(:conn_failed_response) {Hashie::Mash.new(:exit_status => 1, :stdout => "Connection failed.", :stderr => "")}
 
-    it "execute enumerate" do
+    it "should use the supplied client options as defauls" do
+      client = ASM::WsMan::Client.new(endpoint, :transport_timeout => 5)
+      args.pop
+      args << "--transport-timeout=5"
+
+      ASM::Util.expects(:run_command_with_args)
+               .with("env", "WSMAN_PASS=rspec-password", "wsman", "--non-interactive", "enumerate", "rspec-schmea", *args)
+               .returns(response)
+      expect(client.exec("enumerate", "rspec-schmea")).to eq(response.stdout)
+    end
+
+    it "should execute enumerate" do
       ASM::Util.expects(:run_command_with_args)
                .with("env", "WSMAN_PASS=rspec-password", "wsman", "--non-interactive", "enumerate", "rspec-schmea", *args)
                .returns(response)


### PR DESCRIPTION
Previously WsMan::Client accepted a hash of options but ignored these
options and used hard coded defaults instead

Now it uses these options to influence the defaults thus retaining the
ability to make specific per exec adjustments but allowing for different
defaults that would affect all other methods