### PR TITLE
ASM-9333 Increased time-out for reboot job event from 5 to 15 mnts

### DIFF
--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1042,7 +1042,7 @@ module ASM
     def reboot(options={})
       options = {:reboot_job_type => :graceful_with_forced_shutdown,
                  :reboot_start_time => "TIME_NOW",
-                 :timeout => 5 * 60}.merge(options)
+                 :timeout => 15 * 60}.merge(options)
       poll_for_lc_ready(options)
       logger.info("Rebooting server %s" % host)
       resp = create_reboot_job(options)


### PR DESCRIPTION
Previously reboot job has 5 minutes to timeout, sometimes resulting
in timeout  error  waiting for LC ready if servers takes more than 5 minutes.

This PR increases the time to 15 minutes to wait for LC to become ready.