### PR TITLE
ASM-9078 Remove ASM::Util.run_command_simple

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -194,10 +194,25 @@ module ASM
       fcoe_adapters
     end
 
-    def self.run_command_simple(cmd)
-      run_command(cmd)
-    end
-
+    # Execute a command with arguments
+    #
+    # The command will not be invoked within a shell unless the cmd argument itself is a shell.
+    #
+    # WARNING: Commands producing a large amount of stderr vs stdout will deadlock as the
+    # implementation just consumes all stdout before consuming stderr.
+    #
+    # @example
+    #
+    #    [3] pry(main)> ASM::Util.run_command_with_args("echo", "hello", "my", "friend")
+    #    => {"stdout"=>"hello my friend\n", "stderr"=>"", "pid"=>9762, "exit_status"=>0}
+    #    [4] pry(main)> ASM::Util.run_command_with_args("ls", "/noexist1", "/noexist2")
+    #    => {"stdout"=>"",
+    #        "stderr"=>
+    #          "ls: cannot access '/noexist1': No such file or directory\nls: cannot access '/noexist2': No such file or directory\n",
+    #        "pid"=>9842,
+    #        "exit_status"=>2}
+    #
+    # @return [Hashie::Mash] Mash with stdout, stderr, pid and exit_status keys
     def self.run_command_with_args(cmd, *args)
       run_command(cmd, *args)
     end


### PR DESCRIPTION
`ASM::Util.run_command_simple` just executed a string command through
bash. Its usage is prone to command injection attacks since callers
frequently forget to escape unsafe input. And even if they try it's
nigh impossible to guarantee everything dangerous has been stripped
out.

The current pattern we promote is to use
`ASM::Util.run_command_with_args` instead. It executes a command with a
list of arguments. The command itself is not executed through bash so
command injection becomes much more difficult.