### PR TITLE
ESTS-140275 Allow latest versions of gems in gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
-  - jruby-19mode
-  - jruby-9.1.6.0
-  - 2.1.9
+  - jruby-1.7.27
+  - jruby-9.1.15.0
+  - 2.4.3

--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -1,34 +1,34 @@
 Gem::Specification.new do |s|
   s.name        = "dell-asm-util"
   s.version     = "0.1.0"
-  s.licenses    = ["Dell 2015"]
+  s.licenses    = ["Dell 2015-2018"]
   s.summary     = "Util classes for Dell ASM and ASM Puppet Modules"
   s.description = "Util classes for Dell ASM and ASM Puppet Modules"
   s.authors     = ["Dell"]
   s.email       = "asm@dell.com"
   s.homepage    = "https://github.com/dell-asm/dell-asm-util"
 
-  s.add_dependency "aescrypt", "~> 1.0.0"
-  s.add_dependency "hashie", ">= 2.0.5"
-  s.add_dependency "trollop", "~> 2.0"
-  s.add_dependency "nokogiri", "~> 1.6.8"
-  s.add_dependency "i18n", "~> 0.6.5"
-  s.add_dependency "pry", "~> 0.10"
-  s.add_dependency("rest-client", "1.8.0")
-  s.add_dependency "net-ssh", "~> 2.7"
-  s.add_development_dependency "listen", "3.0.7"
+  s.add_dependency "aescrypt"
+  s.add_dependency "hashie"
+  s.add_dependency "trollop"
+  s.add_dependency "nokogiri"
+  s.add_dependency "i18n"
+  s.add_dependency "pry"
+  s.add_dependency "rest-client"
+  s.add_dependency "net-ssh"
+  s.add_development_dependency "listen"
 
-  s.add_development_dependency "logger-colors", "~> 1.0.0"
+  s.add_development_dependency "logger-colors"
   s.add_development_dependency "guard-shell"
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
-  s.add_development_dependency "rainbow", "~> 2.1.0" # for https://github.com/sickill/rainbow/issues/48
+  s.add_development_dependency "rainbow"
   s.add_development_dependency "rubocop", "0.37.2"
-  s.add_development_dependency "rspec", "~> 3"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"
   s.add_development_dependency "puppetlabs_spec_helper", "0.4.1"
-  s.add_development_dependency "json_pure", "2.0.1"
+  s.add_development_dependency "json_pure"
   s.add_development_dependency "coveralls" if Integer(RUBY_VERSION.split(".").first) > 1
 
   s.executables << "wsman_shell.rb"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,9 +26,4 @@ module SpecHelper
   def self.load_fixture(fixture)
     File.read(File.join(FIXTURE_PATH, fixture))
   end
-
-  def self.init_i18n
-    I18n.load_path = Dir[File.expand_path(File.join(File.dirname(__FILE__), "..", "locales", "*.yml"))]
-    I18n.locale = "en".intern
-  end
 end

--- a/spec/unit/asm/network_configuration/nic_type_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_type_spec.rb
@@ -2,10 +2,6 @@ require "spec_helper"
 require "asm/network_configuration"
 
 describe ASM::NetworkConfiguration::NicType do
-  before do
-    SpecHelper.init_i18n
-  end
-
   describe "#ASM::NicType" do
     describe "#ports" do
       it "should parse 2x10Gb" do

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -3,7 +3,6 @@ require "asm/network_configuration"
 
 describe ASM::NetworkConfiguration do
   before do
-    SpecHelper.init_i18n
     ASM::WsMan.stubs(:get_bios_enumeration).returns([])
   end
 


### PR DESCRIPTION
Open up most library version requirements in gemspec. This makes it
easier for the consuming application to specify the versions they
require. This is at the expense of making it more likely that
dell-asm-util tests will fail at some point as new library versions
are released.

Rubocop was left at version 0.37.2 because upgrading that will require
updating code style to match and not fail the new rubocop
checks. Puppetlabs_spec_helper was left at 0.4.1 for now as otherwise
rake task fail.

Travis CI was updated to test against jruby 1.7, jruby 9 and ruby
2.4.3 which are the primary targets now