### PR TITLE
LUD-279 Add support for Mellanox 25Gb NICs

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -190,9 +190,10 @@ module ASM
           interface = Hashie::Mash.new(orig_interface)
           interface.partitions = []
           port_no = name_to_port(orig_interface.name).to_i
-          # Assuming all 10Gb ports enumerate first, which is currently the
-          # case but may not always be...
-          n_ports = card.nictype.n_10gb_ports
+          # Assuming all usable ports enumerate first, which is currently the
+          # case but may not always be... (i.e. on 2x10Gb,2x1Gb combo cards
+          # the 1Gb ports come second)
+          n_ports = card.nictype.n_usable_ports
           max_partitions = card.nictype.n_partitions
           next unless n_ports >= port_no
 

--- a/lib/asm/network_configuration/nic_info.rb
+++ b/lib/asm/network_configuration/nic_info.rb
@@ -161,11 +161,15 @@ module ASM
       #
       # @return [String] the nic type description
       def nic_type
-        return "2x10Gb" if ports.size == 2 && all_ports?(ports, "10 Gbps")
         return "2x1Gb" if ports.size == 2 && all_ports?(ports, "1000 Mbps")
-        return "4x10Gb" if ports.size == 4 && all_ports?(ports, "10 Gbps")
+        return "2x10Gb" if ports.size == 2 && all_ports?(ports, "10 Gbps")
+        return "2x25Gb" if ports.size == 2 && all_ports?(ports, "25 Gbps")
+
         return "4x1Gb" if ports.size == 4 && all_ports?(ports, "1000 Mbps")
+        return "4x10Gb" if ports.size == 4 && all_ports?(ports, "10 Gbps")
+
         return "2x10Gb,2x1Gb" if ports.size == 4 && all_ports?(ports.slice(0, 2), "10 Gbps") && all_ports?(ports.slice(2, 2), "1000 Mbps")
+
         "unknown"
       end
 

--- a/lib/asm/network_configuration/nic_type.rb
+++ b/lib/asm/network_configuration/nic_type.rb
@@ -6,7 +6,7 @@ module ASM
 
       # Creates a new ASM::NicType instance from a nictype string.
       #
-      # Current expected nictype values are "2x10Gb", "4x10Gb" and "2x10Gb,2x1Gb".
+      # Current expected nictype values are "2x10Gb", "4x10Gb", "2x10Gb,2x1Gb" and "2x25Gb".
       # Older templates may also send just "2" or "4", in which case they should
       # be treated as referring to 10Gb ports.
       #
@@ -23,8 +23,13 @@ module ASM
         @nictype = "4x10Gb" if nictype == "4"
       end
 
-      def n_10gb_ports
-        @n_10gb_ports ||= @ports.find_all { |port| port == "10Gb" }.size
+      # Return the number ports that can be configured
+      #
+      # Currently 1Gb NICs are not supported.
+      #
+      # @return [Fixnum]
+      def n_usable_ports
+        @n_10gb_ports ||= @ports.find_all { |port| port != "1Gb" }.size
       end
 
       # Return the number of ports
@@ -34,13 +39,13 @@ module ASM
         @ports.size
       end
 
-      # Returns the number of partitions available for a 10Gb port on this NicType.
+      # Returns the number of partitions available for usable ports on this NicType.
       #
-      # @return [Fixnum] The number of partitions available per 10Gb port
+      # @return [Fixnum]
       def n_partitions
-        raise("NICs without 10Gb ports cannot be partitioned") unless n_10gb_ports > 0
+        raise("NIC type %s does not support partitioning" % @nictype) unless n_usable_ports > 0
 
-        if n_10gb_ports == 2 && n_ports == 2
+        if n_usable_ports == 2 && n_ports == 2
           4
         else
           2

--- a/lib/asm/network_configuration/nic_view.rb
+++ b/lib/asm/network_configuration/nic_view.rb
@@ -79,8 +79,16 @@ module ASM
       def vendor
         return :qlogic if self["VendorName"] =~ /qlogic|broadcom/i
         return :qlogic if self["PCIVendorID"] == "14e4"
+
+        return :mellanox if self["VendorName"] =~ /mellanox/i
+        return :mellanox if self["PCIVendorID"] == "15b3"
+
         return :intel if self["VendorName"] =~ /intel/i
         :intel if self["PCIVendorID"] == "8086" # have seen cases where VendorName not populated
+      end
+
+      def pci_device_id
+        self["PCIDeviceID"]
       end
 
       # The product name of the NIC port

--- a/spec/fixtures/network_configuration/mellanox_connect_x_4_lx_nic_view.xml
+++ b/spec/fixtures/network_configuration/mellanox_connect_x_4_lx_nic_view.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+    <s:Header>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+        <wsa:RelatesTo>uuid:f40702ee-6674-1674-8002-a686af565000</wsa:RelatesTo>
+        <wsa:MessageID>uuid:bd0a5110-6675-1675-a00a-7a25aa4c9a50</wsa:MessageID>
+    </s:Header>
+    <s:Body>
+        <wsen:EnumerateResponse>
+            <wsen:EnumerationContext>bd09dbe0-6675-1675-a009-7a25aa4c9a50</wsen:EnumerationContext>
+        </wsen:EnumerateResponse>
+    </s:Body>
+</s:Envelope>
+        <?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_NICView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:f40faf4a-6674-1674-8003-a686af565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:bd0f5a20-6675-1675-a00b-7a25aa4c9a50</wsa:MessageID>
+</s:Header>
+<s:Body>
+    <wsen:PullResponse>
+        <wsen:Items>
+            <n1:DCIM_NICView>
+                <n1:AutoNegotiation>3</n1:AutoNegotiation>
+                <n1:BusNumber>59</n1:BusNumber>
+                <n1:ControllerBIOSVersion xsi:nil="true"/>
+                <n1:CurrentMACAddress>EC:0D:9A:7F:39:AE</n1:CurrentMACAddress>
+                <n1:DataBusWidth>000B</n1:DataBusWidth>
+                <n1:DeviceDescription>NIC in Slot 1 Port 1 Partition 1</n1:DeviceDescription>
+                <n1:DeviceNumber>0</n1:DeviceNumber>
+                <n1:EFIVersion>14.13.26</n1:EFIVersion>
+                <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+                <n1:FCoEWWNN xsi:nil="true"/>
+                <n1:FQDD>NIC.Slot.1-1-1</n1:FQDD>
+                <n1:FamilyVersion>14.20.18.20</n1:FamilyVersion>
+                <n1:FunctionNumber>0</n1:FunctionNumber>
+                <n1:InstanceID>NIC.Slot.1-1-1</n1:InstanceID>
+                <n1:LastSystemInventoryTime>20180213221659.000000+000</n1:LastSystemInventoryTime>
+                <n1:LastUpdateTime>20180213221658.000000+000</n1:LastUpdateTime>
+                <n1:LinkDuplex>1</n1:LinkDuplex>
+                <n1:LinkSpeed>5</n1:LinkSpeed>
+                <n1:MaxBandwidth>0</n1:MaxBandwidth>
+                <n1:MediaType>SFF_CAGE</n1:MediaType>
+                <n1:MinBandwidth>0</n1:MinBandwidth>
+                <n1:NicMode>3</n1:NicMode>
+                <n1:PCIDeviceID>1015</n1:PCIDeviceID>
+                <n1:PCISubDeviceID>0016</n1:PCISubDeviceID>
+                <n1:PCISubVendorID>15b3</n1:PCISubVendorID>
+                <n1:PCIVendorID>15b3</n1:PCIVendorID>
+                <n1:PermanentFCOEMACAddress/>
+                <n1:PermanentMACAddress>EC:0D:9A:7F:39:AE</n1:PermanentMACAddress>
+                <n1:PermanentiSCSIMACAddress/>
+                <n1:ProductName>Mellanox ConnectX-4 LX 25GbE SFP Adapter - EC:0D:9A:7F:39:AE</n1:ProductName>
+                <n1:Protocol>NIC,RDMA</n1:Protocol>
+                <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+                <n1:SlotLength>0004</n1:SlotLength>
+                <n1:SlotType>00B6</n1:SlotType>
+                <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+                <n1:VendorName>Mellanox Technologies, Inc.</n1:VendorName>
+                <n1:VirtWWN xsi:nil="true"/>
+                <n1:VirtWWPN xsi:nil="true"/>
+                <n1:WWN xsi:nil="true"/>
+                <n1:WWPN xsi:nil="true"/>
+                <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+            </n1:DCIM_NICView>
+            <n1:DCIM_NICView>
+                <n1:AutoNegotiation>3</n1:AutoNegotiation>
+                <n1:BusNumber>95</n1:BusNumber>
+                <n1:ControllerBIOSVersion xsi:nil="true"/>
+                <n1:CurrentMACAddress>EC:0D:9A:7F:3A:76</n1:CurrentMACAddress>
+                <n1:DataBusWidth>000B</n1:DataBusWidth>
+                <n1:DeviceDescription>NIC in Slot 2 Port 1 Partition 1</n1:DeviceDescription>
+                <n1:DeviceNumber>0</n1:DeviceNumber>
+                <n1:EFIVersion>14.13.26</n1:EFIVersion>
+                <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+                <n1:FCoEWWNN xsi:nil="true"/>
+                <n1:FQDD>NIC.Slot.2-1-1</n1:FQDD>
+                <n1:FamilyVersion>14.20.18.20</n1:FamilyVersion>
+                <n1:FunctionNumber>0</n1:FunctionNumber>
+                <n1:InstanceID>NIC.Slot.2-1-1</n1:InstanceID>
+                <n1:LastSystemInventoryTime>20180213221659.000000+000</n1:LastSystemInventoryTime>
+                <n1:LastUpdateTime>20180213221658.000000+000</n1:LastUpdateTime>
+                <n1:LinkDuplex>1</n1:LinkDuplex>
+                <n1:LinkSpeed>5</n1:LinkSpeed>
+                <n1:MaxBandwidth>0</n1:MaxBandwidth>
+                <n1:MediaType>SFF_CAGE</n1:MediaType>
+                <n1:MinBandwidth>0</n1:MinBandwidth>
+                <n1:NicMode>3</n1:NicMode>
+                <n1:PCIDeviceID>1015</n1:PCIDeviceID>
+                <n1:PCISubDeviceID>0016</n1:PCISubDeviceID>
+                <n1:PCISubVendorID>15b3</n1:PCISubVendorID>
+                <n1:PCIVendorID>15b3</n1:PCIVendorID>
+                <n1:PermanentFCOEMACAddress/>
+                <n1:PermanentMACAddress>EC:0D:9A:7F:3A:76</n1:PermanentMACAddress>
+                <n1:PermanentiSCSIMACAddress/>
+                <n1:ProductName>Mellanox ConnectX-4 LX 25GbE SFP Adapter - EC:0D:9A:7F:3A:76</n1:ProductName>
+                <n1:Protocol>NIC,RDMA</n1:Protocol>
+                <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+                <n1:SlotLength>0004</n1:SlotLength>
+                <n1:SlotType>00B6</n1:SlotType>
+                <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+                <n1:VendorName>Mellanox Technologies, Inc.</n1:VendorName>
+                <n1:VirtWWN xsi:nil="true"/>
+                <n1:VirtWWPN xsi:nil="true"/>
+                <n1:WWN xsi:nil="true"/>
+                <n1:WWPN xsi:nil="true"/>
+                <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+            </n1:DCIM_NICView>
+            <n1:DCIM_NICView>
+                <n1:AutoNegotiation>3</n1:AutoNegotiation>
+                <n1:BusNumber>59</n1:BusNumber>
+                <n1:ControllerBIOSVersion xsi:nil="true"/>
+                <n1:CurrentMACAddress>EC:0D:9A:7F:39:AF</n1:CurrentMACAddress>
+                <n1:DataBusWidth>000B</n1:DataBusWidth>
+                <n1:DeviceDescription>NIC in Slot 1 Port 2 Partition 1</n1:DeviceDescription>
+                <n1:DeviceNumber>0</n1:DeviceNumber>
+                <n1:EFIVersion>14.13.26</n1:EFIVersion>
+                <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+                <n1:FCoEWWNN xsi:nil="true"/>
+                <n1:FQDD>NIC.Slot.1-2-1</n1:FQDD>
+                <n1:FamilyVersion>14.20.18.20</n1:FamilyVersion>
+                <n1:FunctionNumber>1</n1:FunctionNumber>
+                <n1:InstanceID>NIC.Slot.1-2-1</n1:InstanceID>
+                <n1:LastSystemInventoryTime>20180302212400.000000+000</n1:LastSystemInventoryTime>
+                <n1:LastUpdateTime>20180302212400.000000+000</n1:LastUpdateTime>
+                <n1:LinkDuplex>1</n1:LinkDuplex>
+                <n1:LinkSpeed>5</n1:LinkSpeed>
+                <n1:MaxBandwidth>0</n1:MaxBandwidth>
+                <n1:MediaType>SFF_CAGE</n1:MediaType>
+                <n1:MinBandwidth>0</n1:MinBandwidth>
+                <n1:NicMode>3</n1:NicMode>
+                <n1:PCIDeviceID>1015</n1:PCIDeviceID>
+                <n1:PCISubDeviceID>0016</n1:PCISubDeviceID>
+                <n1:PCISubVendorID>15b3</n1:PCISubVendorID>
+                <n1:PCIVendorID>15b3</n1:PCIVendorID>
+                <n1:PermanentFCOEMACAddress/>
+                <n1:PermanentMACAddress>EC:0D:9A:7F:39:AF</n1:PermanentMACAddress>
+                <n1:PermanentiSCSIMACAddress/>
+                <n1:ProductName>Mellanox ConnectX-4 LX 25GbE SFP Adapter - EC:0D:9A:7F:39:AF</n1:ProductName>
+                <n1:Protocol>NIC,RDMA</n1:Protocol>
+                <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+                <n1:SlotLength>0004</n1:SlotLength>
+                <n1:SlotType>00B6</n1:SlotType>
+                <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+                <n1:VendorName>Mellanox Technologies, Inc.</n1:VendorName>
+                <n1:VirtWWN xsi:nil="true"/>
+                <n1:VirtWWPN xsi:nil="true"/>
+                <n1:WWN xsi:nil="true"/>
+                <n1:WWPN xsi:nil="true"/>
+                <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+            </n1:DCIM_NICView>
+            <n1:DCIM_NICView>
+                <n1:AutoNegotiation>3</n1:AutoNegotiation>
+                <n1:BusNumber>95</n1:BusNumber>
+                <n1:ControllerBIOSVersion xsi:nil="true"/>
+                <n1:CurrentMACAddress>EC:0D:9A:7F:3A:77</n1:CurrentMACAddress>
+                <n1:DataBusWidth>000B</n1:DataBusWidth>
+                <n1:DeviceDescription>NIC in Slot 2 Port 2 Partition 1</n1:DeviceDescription>
+                <n1:DeviceNumber>0</n1:DeviceNumber>
+                <n1:EFIVersion>14.13.26</n1:EFIVersion>
+                <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+                <n1:FCoEWWNN xsi:nil="true"/>
+                <n1:FQDD>NIC.Slot.2-2-1</n1:FQDD>
+                <n1:FamilyVersion>14.20.18.20</n1:FamilyVersion>
+                <n1:FunctionNumber>1</n1:FunctionNumber>
+                <n1:InstanceID>NIC.Slot.2-2-1</n1:InstanceID>
+                <n1:LastSystemInventoryTime>20180302212400.000000+000</n1:LastSystemInventoryTime>
+                <n1:LastUpdateTime>20180302212400.000000+000</n1:LastUpdateTime>
+                <n1:LinkDuplex>1</n1:LinkDuplex>
+                <n1:LinkSpeed>5</n1:LinkSpeed>
+                <n1:MaxBandwidth>0</n1:MaxBandwidth>
+                <n1:MediaType>SFF_CAGE</n1:MediaType>
+                <n1:MinBandwidth>0</n1:MinBandwidth>
+                <n1:NicMode>3</n1:NicMode>
+                <n1:PCIDeviceID>1015</n1:PCIDeviceID>
+                <n1:PCISubDeviceID>0016</n1:PCISubDeviceID>
+                <n1:PCISubVendorID>15b3</n1:PCISubVendorID>
+                <n1:PCIVendorID>15b3</n1:PCIVendorID>
+                <n1:PermanentFCOEMACAddress/>
+                <n1:PermanentMACAddress>EC:0D:9A:7F:3A:77</n1:PermanentMACAddress>
+                <n1:PermanentiSCSIMACAddress/>
+                <n1:ProductName>Mellanox ConnectX-4 LX 25GbE SFP Adapter - EC:0D:9A:7F:3A:77</n1:ProductName>
+                <n1:Protocol>NIC,RDMA</n1:Protocol>
+                <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+                <n1:SlotLength>0004</n1:SlotLength>
+                <n1:SlotType>00B6</n1:SlotType>
+                <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+                <n1:VendorName>Mellanox Technologies, Inc.</n1:VendorName>
+                <n1:VirtWWN xsi:nil="true"/>
+                <n1:VirtWWPN xsi:nil="true"/>
+                <n1:WWN xsi:nil="true"/>
+                <n1:WWPN xsi:nil="true"/>
+                <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+            </n1:DCIM_NICView>
+        </wsen:Items>
+        <wsen:EndOfSequence/>
+    </wsen:PullResponse>
+</s:Body>
+</s:Envelope>

--- a/spec/fixtures/network_configuration/x710_i350_nic_view.xml
+++ b/spec/fixtures/network_configuration/x710_i350_nic_view.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:f40702ee-6674-1674-8002-a686af565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:bd0a5110-6675-1675-a00a-7a25aa4c9a50</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsen:EnumerationContext>bd09dbe0-6675-1675-a009-7a25aa4c9a50</wsen:EnumerationContext>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_NICView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:f40faf4a-6674-1674-8003-a686af565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:bd0f5a20-6675-1675-a00b-7a25aa4c9a50</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:PullResponse>
+      <wsen:Items>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>24</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:5B:B2:12</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 2 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>2.1.2</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>24:6e:96:5b:b2:13</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-2-1</n1:FQDD>
+          <n1:FamilyVersion>18.0.17</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20171016011647.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20171016003951.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>SFF_CAGE</n1:MediaType>
+          <n1:MinBandwidth>25</n1:MinBandwidth>
+          <n1:NicMode>2</n1:NicMode>
+          <n1:PCIDeviceID>1572</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>0000</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>24:6e:96:5b:b2:13</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:6E:96:5B:B2:12</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G X710 rNDC - 24:6E:96:5B:B2:12</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:5B:B2:31</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 4 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.4.30</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-4-1</n1:FQDD>
+          <n1:FamilyVersion>18.0.17</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-4-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20171016011647.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20171016003951.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>Base T</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f9a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:5B:B2:31</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P X710/I350 rNDC - 24:6E:96:5B:B2:31</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:5B:B2:30</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 3 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>7.4.30</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-3-1</n1:FQDD>
+          <n1:FamilyVersion>18.0.17</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-3-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20180213213027.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20180213213027.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>Base T</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f9a</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>24:6E:96:5B:B2:30</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P X710/I350 rNDC - 24:6E:96:5B:B2:30</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>3</n1:AutoNegotiation>
+          <n1:BusNumber>24</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress>24:6E:96:5B:B2:10</n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceDescription>Integrated NIC 1 Port 1 Partition 1</n1:DeviceDescription>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion>2.1.2</n1:EFIVersion>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN>24:6e:96:5b:b2:11</n1:FCoEWWNN>
+          <n1:FQDD>NIC.Integrated.1-1-1</n1:FQDD>
+          <n1:FamilyVersion>18.0.17</n1:FamilyVersion>
+          <n1:FunctionNumber>0</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20180213213027.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20180213213027.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>0</n1:LinkDuplex>
+          <n1:LinkSpeed>0</n1:LinkSpeed>
+          <n1:MaxBandwidth>100</n1:MaxBandwidth>
+          <n1:MediaType>SFF_CAGE</n1:MediaType>
+          <n1:MinBandwidth>25</n1:MinBandwidth>
+          <n1:NicMode>2</n1:NicMode>
+          <n1:PCIDeviceID>1572</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f99</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress>24:6e:96:5b:b2:11</n1:PermanentFCOEMACAddress>
+          <n1:PermanentMACAddress>24:6E:96:5B:B2:10</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Ethernet 10G 4P X710/I350 rNDC - 24:6E:96:5B:B2:10</n1:ProductName>
+          <n1:Protocol>NIC</n1:Protocol>
+          <n1:ReceiveFlowControl>3</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN xsi:nil="true"/>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+      </wsen:Items>
+      <wsen:EndOfSequence/>
+    </wsen:PullResponse>
+  </s:Body>
+</s:Envelope>

--- a/spec/unit/asm/network_configuration/nic_info_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_info_spec.rb
@@ -86,6 +86,32 @@ describe ASM::NetworkConfiguration::NicInfo do
         expect(nic_infos[0].card_prefix).to eq("NIC.Integrated.1")
         expect(nic_infos[1].card_prefix).to eq("NIC.Slot.4")
       end
+
+      it "should recognize Intel X710/I350 2x10Gb,2x1Gb combo card" do
+        nic_views_xml = SpecHelper.load_fixture("network_configuration/x710_i350_nic_view.xml")
+        ASM::WsMan.expects(:invoke)
+                  .with(endpoint, "enumerate", "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_NICView", :logger => logger)
+                  .returns(nic_views_xml)
+        ASM::WsMan.expects(:get_bios_enumeration).with(endpoint, logger).returns([])
+        nic_infos = ASM::NetworkConfiguration::NicInfo.fetch(endpoint, logger)
+        expect(nic_infos.size).to eq(1)
+        expect(nic_infos[0].nic_type).to eq("2x10Gb,2x1Gb")
+        expect(nic_infos[0].card_prefix).to eq("NIC.Integrated.1")
+      end
+
+      it "should recognize Mellanox ConnectX-4 LX 25Gb slot card" do
+        nic_views_xml = SpecHelper.load_fixture("network_configuration/mellanox_connect_x_4_lx_nic_view.xml")
+        ASM::WsMan.expects(:invoke)
+                  .with(endpoint, "enumerate", "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_NICView", :logger => logger)
+                  .returns(nic_views_xml)
+        ASM::WsMan.expects(:get_bios_enumeration).with(endpoint, logger).returns([])
+        nic_infos = ASM::NetworkConfiguration::NicInfo.fetch(endpoint, logger)
+        expect(nic_infos.size).to eq(2)
+        expect(nic_infos[0].nic_type).to eq("2x25Gb")
+        expect(nic_infos[0].card_prefix).to eq("NIC.Slot.1")
+        expect(nic_infos[1].nic_type).to eq("2x25Gb")
+        expect(nic_infos[1].card_prefix).to eq("NIC.Slot.2")
+      end
     end
 
     describe ".create" do

--- a/spec/unit/asm/network_configuration/nic_port_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_port_spec.rb
@@ -185,4 +185,24 @@ describe ASM::NetworkConfiguration::NicPort do
       expect(nic_port.n_partitions).to eq(1)
     end
   end
+
+  describe "#ipxe_iso_supported?" do
+    let(:nic_info) { ASM::NetworkConfiguration::NicView.new("FQDD" => "NIC.Integrated.1-1-1") }
+    let(:nic_port) { ASM::NetworkConfiguration::NicPort.new([nic_info], 2, logger) }
+
+    it "should return true for Intel NICs" do
+      nic_port.expects(:vendor).returns(:intel)
+      expect(nic_port.ipxe_iso_supported?).to be_truthy
+    end
+
+    it "should return true for Mellanox NICs" do
+      nic_port.expects(:vendor).returns(:mellanox)
+      expect(nic_port.ipxe_iso_supported?).to be_truthy
+    end
+
+    it "should return false otherwise" do
+      nic_port.expects(:vendor).returns(:qlogic)
+      expect(nic_port.ipxe_iso_supported?).to be_falsey
+    end
+  end
 end

--- a/spec/unit/asm/network_configuration/nic_type_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_type_spec.rb
@@ -53,7 +53,7 @@ describe ASM::NetworkConfiguration::NicType do
 
       it "should fail if not 10Gb NICs" do
         expect { ASM::NetworkConfiguration::NicType.new("4x1Gb").n_partitions }
-          .to raise_error("NICs without 10Gb ports cannot be partitioned")
+          .to raise_error("NIC type 4x1Gb does not support partitioning")
       end
     end
   end


### PR DESCRIPTION
Additionally added some specific checks for Intel X710 which was
already supported. Both the X520 and X710 have both 2x10Gb and 4x10Gb
variants but the previous X520 check was specific to 2-port.
