### PR TITLE
LUD-522 Deadlock when running "puppet asm process_node"

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -288,22 +288,34 @@ module ASM
         Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
           stdin.close
 
-          # Drain stdout
-          while line = stdout.gets
-            fh.puts(line)
-            # Interleave stderr if available
-            while stderr.ready?
-              if err = stderr.gets
-                fh.puts(err)
+          files = [stdout, stderr]
+
+          # Attempt to interleave stdout and stderr if possible
+          # by using gets instead of read_nonblock to read a
+          # line at a time. Slower but interleaves better.
+          until files.empty? do
+            ready = IO.select(files)
+            readable = ready[0]
+            readable.each do |f|
+              begin
+                data = f.gets
+                if data.nil?
+                  # gets returns nil on EOF so remove this file
+                  # from the list of files to select on (read from)
+                  files.delete(f)
+                else
+                  fh.write data
+                  fh.flush
+                end
+              rescue IOError => e
+                # A catch-all to prevent spinning in case
+                # some weird exception happens - just delete
+                # the offending file from the list
+                files.delete(f)
               end
             end
           end
-
-          # Drain stderr
-          while line = stderr.gets
-            fh.puts(line)
-          end
-
+          
           fh.close
           raise("#{cmd} failed; output in #{outfile}") unless wait_thr.value.exitstatus == 0
         end


### PR DESCRIPTION
Fixed code to use IO::select which waits until data is available
or EOF on an array of files (stdout and stderr in this case). The
code still reads from those streams line by line in an attempt
to interleave the output to preserve previous behavior.

DO NOT MERGE 

No tests written yet