### PR TITLE
LUD-421b poll_for_lc_ready to handle API errors

### DIFF
--- a/lib/asm/firmware.rb
+++ b/lib/asm/firmware.rb
@@ -95,7 +95,9 @@ module ASM
       firmware_instance.update_idrac_firmware(main, force_restart, wsman_instance)
 
       # After updating Ensure LC is up and in good state before exiting
-      wsman_instance.poll_for_lc_ready
+      ASM::Util.block_and_retry_until_ready(1800, [ASM::WsMan::RetryException, ASM::WsMan::Error, ASM::WsMan::ResponseError], 60) do
+        wsman_instance.poll_for_lc_ready # Make sure Lc status was ready
+      end
     end
 
     # Clearing the job_queue with retry


### PR DESCRIPTION
For the service firmware update task, poll_for_lc_ready breaks often
by the endpoint being in a reboot stage.

Now it handles exception caused by API calls failing to reach iDRAC
servers.