### PR TITLE
LUD-1187 always wait and rescue timeout after firmware update

### DIFF
--- a/lib/asm/firmware.rb
+++ b/lib/asm/firmware.rb
@@ -91,6 +91,9 @@ module ASM
       unless pre.empty?
         logger.debug("LC Update required, installing first")
         firmware_instance.update_idrac_firmware(pre, force_restart, wsman_instance)
+        ASM::Util.block_and_retry_until_ready(1800, [ASM::WsMan::RetryException, ASM::WsMan::Error, ASM::WsMan::ResponseError], 60) do
+          wsman_instance.poll_for_lc_ready
+        end
       end
       firmware_instance.update_idrac_firmware(main, force_restart, wsman_instance)
 

--- a/spec/unit/asm/firmware_spec.rb
+++ b/spec/unit/asm/firmware_spec.rb
@@ -130,7 +130,7 @@ describe ASM::Firmware do
     it "should upate the firmware" do
       firmware_obj.expects(:clear_job_queue_retry).with(wsman).returns(nil)
       firmware_obj.expects(:update_idrac_firmware).returns(nil).twice
-      wsman.expects(:poll_for_lc_ready)
+      wsman.expects(:poll_for_lc_ready).twice
       ASM::Firmware.idrac_fw_install_from_uri(config, resource_hash, device_config, logger)
     end
 


### PR DESCRIPTION
It looks like we don't wait for the LC status to be ready when we
perform the firmware update job for the  LC. This causes issue for
the next non-LC firmware updates.