### PR TITLE
LUD-1437,LUD-1455 Disable iPXE ISO usage

### DIFF
--- a/lib/asm/network_configuration/nic_port.rb
+++ b/lib/asm/network_configuration/nic_port.rb
@@ -58,7 +58,8 @@ module ASM
       #
       # @return [Boolean]
       def ipxe_iso_supported?
-        [:intel, :mellanox].include?(vendor)
+        # Seeing various iPXE ISO issues currently so disabling. See LUD-1437 and LUD-1455
+        false
       end
 
       # Whether the NIC port belongs to a Broadcom / QLogic 57800 NIC

--- a/spec/unit/asm/network_configuration/nic_port_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_port_spec.rb
@@ -190,18 +190,7 @@ describe ASM::NetworkConfiguration::NicPort do
     let(:nic_info) { ASM::NetworkConfiguration::NicView.new("FQDD" => "NIC.Integrated.1-1-1") }
     let(:nic_port) { ASM::NetworkConfiguration::NicPort.new([nic_info], 2, logger) }
 
-    it "should return true for Intel NICs" do
-      nic_port.expects(:vendor).returns(:intel)
-      expect(nic_port.ipxe_iso_supported?).to be_truthy
-    end
-
-    it "should return true for Mellanox NICs" do
-      nic_port.expects(:vendor).returns(:mellanox)
-      expect(nic_port.ipxe_iso_supported?).to be_truthy
-    end
-
     it "should return false otherwise" do
-      nic_port.expects(:vendor).returns(:qlogic)
       expect(nic_port.ipxe_iso_supported?).to be_falsey
     end
   end


### PR DESCRIPTION
Seeing various issues on iPXE ISO boot so disabling:

- ISO doesn't see port 2 on Intel X710 NICs
- Mellanox ConnectX-4 LX OS install times very slow