### PR TITLE
LUD-1453 force to clear iDRAC job queue

### DIFF
--- a/lib/asm/firmware.rb
+++ b/lib/asm/firmware.rb
@@ -114,7 +114,8 @@ module ASM
       begin
         attempts += 1
         logger.debug("Clearing the Job Queue...")
-        resp = wsman.delete_job_queue(:job_id => "JID_CLEARALL")
+        clear_job_id = attempts > 1 ?  "JID_CLEARALL_FORCE" : "JID_CLEARALL"
+        resp = wsman.delete_job_queue(:job_id => clear_job_id)
 
         if resp[:return_value] == "0"
           logger.debug("Jobs in job queue was cleared successfully...")


### PR DESCRIPTION
There are few occasions where FW/SW update job fails, due to iDRAC
jobs that are stuck in the queue. To mitigate this type of failures,
we now attempt to force clear the iDRAC job queue if the first
try fails.