### PR TITLE
VXFM-2197 Add the support for 4N

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -159,6 +159,18 @@ module ASM
       end.flatten.compact
     end
 
+    # Returns list of FQDDs for the NICS associated with specified network ID
+    #
+    # @params [String] network_id
+    # @return [Array] List of FQDDs associated with the network ID
+    def fqdds_for_network(network_id)
+      collect_from_partitions do |partition|
+        (partition.networkObjects || []).collect do |network_obj|
+          partition.fqdds if network_obj["id"] == network_id
+        end
+      end.flatten.compact
+    end
+
     # Returns the network object for the given network type.  This method raises
     # an exception if more than one network is found, so it is never valid to
     # call it for network types that may have more than one network associated

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -161,6 +161,12 @@ describe ASM::NetworkConfiguration do
       expect(partitions.size).to eq(0)
     end
 
+    it "should find fqdds by network_id" do
+      fqdds = net_config.fqdds_for_network("ff808081508c08e301508c7e1ebf065e")
+
+      expect(fqdds.size).to eq(0)
+    end
+
     it "should find multiple network types" do
       partitions = net_config.get_partitions("PUBLIC_LAN", "PRIVATE_LAN")
       expect(partitions.size).to eq(2)


### PR DESCRIPTION
Including method to return list of FQDDs mapped to a specific network. This helps in identifying the NICS mapped to a specific nettwork type