### PR TITLE
VXFM-5119 Upgrade to latest nokogiri and rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,19 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  TargetRubyVersion: 2.3.3
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Naming/PredicateName:
+  Enabled: false
 
 Style/RegexpLiteral:
   Enabled: false
@@ -11,6 +24,9 @@ Style/StringLiterals:
 Style/FormatString:
   EnforcedStyle: percent
 
+Style/FormatStringToken:
+  Enabled: false
+
 Style/SpecialGlobalVars:
   Enabled: false
 
@@ -20,23 +36,14 @@ Style/HashSyntax:
 Style/WordArray:
   Enabled: false
 
-Style/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: no_space
-
 Style/SignalException:
   EnforcedStyle: only_raise
 
 Style/RescueModifier:
   Enabled: false
 
-Style/SpaceInsideBlockBraces:
-  Enabled: false
-
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
-Style/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: no_space
+Style/RescueStandardError:
+  EnforcedStyle: implicit
 
 Style/Documentation:
   Severity: warning
@@ -47,13 +54,7 @@ Style/EachWithObject:
 Style/GuardClause:
   Enabled: false
 
-Style/PredicateName:
-  Enabled: false
-
 Style/DoubleNegation:
-  Enabled: false
-
-Style/Documentation:
   Enabled: false
 
 Style/PerlBackrefs:
@@ -73,6 +74,13 @@ Lint/UnusedMethodArgument:
 
 Lint/AssignmentInCondition:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Gemfile'
+    - 'Rakefile'
+    - '*.gemspec'
+    - 'spec/**/*.rb'
 
 Metrics/LineLength:
   Max: 180

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 sudo: false
 rvm:
-  - jruby-1.7.27
   - jruby-9.1.15.0
   - 2.4.3
-before_install:
-  - gem install bundler -v '< 2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify dependencies in dell-asm-util.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems"
 require "puppetlabs_spec_helper/rake_tasks"
 require "rake"

--- a/bin/wsman_shell.rb
+++ b/bin/wsman_shell.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/ruby
 
+# frozen_string_literal: true
+
 require "trollop"
 require "pathname"
 require "pry"

--- a/dell-asm-util.gemspec
+++ b/dell-asm-util.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "dell-asm-util"
   s.version     = "0.1.0"
@@ -10,27 +12,27 @@ Gem::Specification.new do |s|
 
   s.add_dependency "aescrypt"
   s.add_dependency "hashie"
-  s.add_dependency "trollop"
   s.add_dependency "i18n"
+  s.add_dependency "net-ssh"
+  s.add_dependency "nokogiri"
   s.add_dependency "pry"
   s.add_dependency "rest-client"
-  s.add_dependency "net-ssh"
-  s.add_dependency "nokogiri", "<= 1.8.4"
+  s.add_dependency "trollop"
 
-  s.add_development_dependency "listen"
-  s.add_development_dependency "rake", "12.2.1"
-  s.add_development_dependency "logger-colors"
+  s.add_development_dependency "coveralls" if Integer(RUBY_VERSION.split(".").first) > 1
   s.add_development_dependency "guard-shell"
-  s.add_development_dependency "yard"
+  s.add_development_dependency "json_pure"
   s.add_development_dependency "kramdown"
-  s.add_development_dependency "rainbow"
-  s.add_development_dependency "rubocop", "0.37.2"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "listen"
+  s.add_development_dependency "logger-colors"
   s.add_development_dependency "mocha"
   s.add_development_dependency "puppet"
   s.add_development_dependency "puppetlabs_spec_helper", "0.4.1"
-  s.add_development_dependency "json_pure"
-  s.add_development_dependency "coveralls" if Integer(RUBY_VERSION.split(".").first) > 1
+  s.add_development_dependency "rainbow"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "rubocop", "0.65.0"
+  s.add_development_dependency "yard"
 
   s.executables << "wsman_shell.rb"
 

--- a/lib/asm/errors.rb
+++ b/lib/asm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ASM
   class Error < StandardError; end
   class CommandException < Error; end

--- a/lib/asm/ipmi.rb
+++ b/lib/asm/ipmi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "asm/ipmi/client"
 
 module ASM
@@ -52,13 +54,11 @@ module ASM
     # @return [Symbol] :on or :off
     def power_state
       response = client.exec("power status")
-      unless response =~ /Chassis Power is\s+(\S+)/m
-        raise(ASM::Error, "Invalid IPMI power status response: %s" % response)
-      end
+      raise(ASM::Error, "Invalid IPMI power status response: %s" % response) unless response =~ /Chassis Power is\s+(\S+)/m
+
       state = $1.downcase
-      unless %w(on off).include?(state)
-        raise(ASM::Error, "Invalid IPMI power state %s; full response: %s" % [state, response])
-      end
+      raise(ASM::Error, "Invalid IPMI power state %s; full response: %s" % [state, response]) unless %w[on off].include?(state)
+
       logger.debug("Current power status: #{response}")
       state.to_sym
     end

--- a/lib/asm/network_configuration/nic_port.rb
+++ b/lib/asm/network_configuration/nic_port.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "logger"
 
 module ASM
@@ -17,6 +19,7 @@ module ASM
       # @return [NicPort]
       def initialize(partitions, n_ports, logger=nil)
         raise(ArgumentError, "At least one NicView required to create a NicPort") if partitions.empty?
+
         @partitions = partitions
         @n_ports = n_ports
         @logger = logger || Logger.new(nil)
@@ -148,6 +151,7 @@ module ASM
         return 4 if is_qlogic_57810?
         return 2 if is_qlogic_57840?
         return 2 if is_qlogic_57800? && port.between?(1, 2)
+
         1
       end
 

--- a/lib/asm/network_configuration/nic_type.rb
+++ b/lib/asm/network_configuration/nic_type.rb
@@ -1,5 +1,13 @@
+# frozen_string_literal: true
+
 module ASM
   class NetworkConfiguration
+    # NicType provides overview information about a single logical NIC
+    #
+    # At the WS-Man level via DCIM_NicView, NIC information is
+    # reported from a per-port and/or per-partition point of
+    # view. This class ties the individual NIC views together into a
+    # single logical NIC.
     class NicType
       attr_accessor(:nictype)
       attr_accessor(:ports)
@@ -29,7 +37,7 @@ module ASM
       #
       # @return [Fixnum]
       def n_usable_ports
-        @n_10gb_ports ||= @ports.find_all { |port| port != "1Gb" }.size
+        @n_usable_ports ||= @ports.find_all { |port| port != "1Gb" }.size
       end
 
       # Return the number of ports
@@ -43,7 +51,7 @@ module ASM
       #
       # @return [Fixnum]
       def n_partitions
-        raise("NIC type %s does not support partitioning" % @nictype) unless n_usable_ports > 0
+        raise("NIC type %s does not support partitioning" % @nictype) unless n_usable_ports.positive?
 
         if n_usable_ports == 2 && n_ports == 2
           4

--- a/lib/asm/translatable.rb
+++ b/lib/asm/translatable.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require "i18n"
 
 module ASM
+  # Module for translation method
   module Translatable
     def t(msgid, default, args={})
       I18n.config.enforce_available_locales = false unless I18n.config.enforce_available_locales

--- a/lib/asm/transport/racadm.rb
+++ b/lib/asm/transport/racadm.rb
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
 require "net/ssh"
 
 module ASM
   class Transport
     class IdracResetError < StandardError; end
+
+    # Utility class for interacting with Dell servers via RACADM
     class Racadm
       attr_reader :endpoint, :logger
 

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 require "pathname"
 require "asm/network_configuration/nic_info"
 require "asm/util"
@@ -9,22 +10,20 @@ require "rexml/document"
 require "uri"
 
 module ASM
+  # Utility class for interacting with Dell servers via WS-MAN
   class WsMan
-    # rubocop:disable Metrics/LineLength
-    BIOS_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_BIOSService&SystemName=DCIM:ComputerSystem&Name=DCIM:BIOSService".freeze
-    DEPLOYMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_OSDeploymentService&SystemName=DCIM:ComputerSystem&Name=DCIM:OSDeploymentService".freeze
-    JOB_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=DCIM_JobService&Name=JobService&SystemName=Idrac&SystemCreationClassName=DCIM_ComputerSystem&__cimnamespace=root/dcim".freeze
-    LC_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_LCService&SystemName=DCIM:ComputerSystem&Name=DCIM:LCService".freeze
-    LC_RECORD_LOG_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_LCRecordLog?__cimnamespace=root/dcim".freeze
-    POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem&Name=srv:system".freeze
-    POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem&SystemName=systemmc&CreationClassName=DCIM_CSPowerManagementService&Name=pwrmgtsvc:1".freeze
-    SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate".freeze
-    IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState".freeze
-    APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_iDRACCardService&SystemName=DCIM:ComputerSystem&Name=DCIM:iDRACCardService".freeze
-    SYSTEM_MANAGEMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SystemManagementService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_SystemManagementService&SystemName=srv:system&Name=DCIM:SystemManagementService".freeze
-    RAID_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_RAIDService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_RAIDService&SystemName=DCIM:ComputerSystem&Name=DCIM:RAIDService".freeze
-
-    # rubocop:enable Metrics/LineLength
+    BIOS_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_BIOSService&SystemName=DCIM:ComputerSystem&Name=DCIM:BIOSService"
+    DEPLOYMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_OSDeploymentService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_OSDeploymentService&SystemName=DCIM:ComputerSystem&Name=DCIM:OSDeploymentService"
+    JOB_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=DCIM_JobService&Name=JobService&SystemName=Idrac&SystemCreationClassName=DCIM_ComputerSystem&__cimnamespace=root/dcim"
+    LC_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_LCService&SystemName=DCIM:ComputerSystem&Name=DCIM:LCService"
+    LC_RECORD_LOG_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_LCRecordLog?__cimnamespace=root/dcim"
+    POWER_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_ComputerSystem?CreationClassName=DCIM_ComputerSystem&Name=srv:system"
+    POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem&SystemName=systemmc&CreationClassName=DCIM_CSPowerManagementService&Name=pwrmgtsvc:1"
+    SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate"
+    IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState"
+    APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_iDRACCardService&SystemName=DCIM:ComputerSystem&Name=DCIM:iDRACCardService"
+    SYSTEM_MANAGEMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SystemManagementService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_SystemManagementService&SystemName=srv:system&Name=DCIM:SystemManagementService"
+    RAID_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_RAIDService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_RAIDService&SystemName=DCIM:ComputerSystem&Name=DCIM:RAIDService"
 
     attr_reader :client
 
@@ -344,9 +343,11 @@ module ASM
       begin
         ret = client.enumerate("http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_CSAssociatedPowerManagementService")
         raise(Error, "No power management enumerations found") if ret.empty?
+
         power_state = ret.first[:power_state]
         return :on if power_state == "2"
         return :off if power_state == "13"
+
         raise(Error, "Invalid power state returned: %s" % power_state)
       rescue
         if retry_counter < 8
@@ -361,7 +362,7 @@ module ASM
 
     def self.reboot(endpoint, logger=nil)
       # Create the reboot job
-      logger.debug("Rebooting server #{endpoint[:host]}") if logger
+      logger&.debug("Rebooting server #{endpoint[:host]}")
       instanceid = invoke(endpoint,
                           "CreateRebootJob",
                           SOFTWARE_INSTALLATION_SERVICE,
@@ -379,7 +380,7 @@ module ASM
                             "StartTimeInterval" => "TIME_NOW"
                           },
                           :logger => logger)
-      logger.debug "Job Message #{jobmessage}" if logger
+      logger&.debug "Job Message #{jobmessage}"
       true
     end
 
@@ -460,12 +461,13 @@ module ASM
       nics.reject(&:disabled?).each do |nic|
         nic.ports.each do |port|
           next unless port.link_speed == "10 Gbps"
+
           port.partitions.each do |partition|
             ret[partition.fqdd] = partition.mac_address
           end
         end
       end
-      logger.debug("********* MAC Address List is #{ret.inspect} **************") if logger
+      logger&.debug("********* MAC Address List is #{ret.inspect} **************")
       ret
     end
 
@@ -479,12 +481,13 @@ module ASM
       nics.reject(&:disabled?).each do |nic|
         nic.ports.each do |port|
           next unless port.link_speed == "10 Gbps"
+
           port.partitions.each do |partition|
             ret[partition.fqdd] = partition["PermanentMACAddress"]
           end
         end
       end
-      logger.debug("********* MAC Address List is #{ret.inspect} **************") if logger
+      logger&.debug("********* MAC Address List is #{ret.inspect} **************")
       ret
     end
 
@@ -507,9 +510,8 @@ module ASM
       end
 
       # Apparently we sometimes see a spurious empty return value...
-      if ret.empty? && tries == 0
-        ret = get_nic_view(endpoint, logger, tries + 1)
-      end
+      ret = get_nic_view(endpoint, logger, tries + 1) if ret.empty? && tries.zero?
+
       ret
     end
 
@@ -540,7 +542,7 @@ module ASM
                     :logger => logger)
       nic_views = resp.split("<n1:DCIM_NICView>")
       nic_views.shift
-      nic_views.each do |nic_view|
+      nic_views.each do |nic_view| # rubocop:disable Metrics/BlockLength
         nic_name = nil
         nic_view.split("\n").each do |line|
           if line =~ %r{<n1:FQDD>(\S+)</n1:FQDD>}
@@ -548,7 +550,8 @@ module ASM
             fcoe_info[nic_name] = {}
           end
         end
-        nic_view.split("\n").each do |line|
+
+        nic_view.split("\n").each do |line| # rubocop:disable Metrics/BlockLength
           if line =~ %r{<n1:FCoEWWNN>(\S+)</n1:FCoEWWNN>}
             fcoe_wwnn = $1
             fcoe_info[nic_name]["fcoe_wwnn"] = fcoe_wwnn
@@ -591,7 +594,7 @@ module ASM
         fcoe_info.delete(nic_name) if nic_name.include?("Embedded")
       end
 
-      logger.debug("FCoE info: #{fcoe_info.inspect} **************") if logger
+      logger&.debug("FCoE info: #{fcoe_info.inspect} **************")
       fcoe_info
     end
 
@@ -611,7 +614,7 @@ module ASM
     def create_reboot_job(params={})
       client.invoke("CreateRebootJob", SOFTWARE_INSTALLATION_SERVICE,
                     :params => params,
-                    :optional_params => [:reboot_start_time, :reboot_job_type],
+                    :optional_params => %i[reboot_start_time reboot_job_type],
                     :return_value => "4096")
     end
 
@@ -646,7 +649,7 @@ module ASM
       input_file = params.delete(:input_file)
       options = {
         :params => params,
-        :optional_params => [:job_array, :start_time_interval, :until_time],
+        :optional_params => %i[job_array start_time_interval until_time],
         :return_value => "0"
       }
       options[:input_file] = input_file if input_file
@@ -664,7 +667,7 @@ module ASM
     def delete_job_queue(params={})
       client.invoke("DeleteJobQueue", JOB_SERVICE,
                     :params => params,
-                    :optional_params => [:job_id],
+                    :optional_params => %i[job_id],
                     :return_value => "0")
     end
 
@@ -749,8 +752,8 @@ module ASM
       end
       client.invoke("BootToNetworkISO", DEPLOYMENT_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                    :optional_params => [:workgroup, :user_name, :password, :hash_type, :hash_value, :auto_connect],
+                    :required_params => %i[ip_address share_name share_type image_name],
+                    :optional_params => %i[workgroup user_name password hash_type hash_value auto_connect],
                     :return_value => "4096")
     end
 
@@ -770,8 +773,8 @@ module ASM
       end
       client.invoke("ConnectNetworkISOImage", DEPLOYMENT_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                    :optional_params => [:workgroup, :user_name, :password, :hash_type, :hash_value, :auto_connect],
+                    :required_params => %i[ip_address share_name share_type image_name],
+                    :optional_params => %i[workgroup user_name password hash_type hash_value auto_connect],
                     :return_value => "4096")
     end
 
@@ -800,8 +803,8 @@ module ASM
 
       client.invoke("ConnectRFSISOImage", DEPLOYMENT_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                    :optional_params => [:workgroup, :username, :password, :hash_type, :hash_value, :auto_connect],
+                    :required_params => %i[ip_address share_name share_type image_name],
+                    :optional_params => %i[workgroup username password hash_type hash_value auto_connect],
                     :return_value => "4096")
     end
 
@@ -865,7 +868,7 @@ module ASM
     #
     # @example response
     #   {:drivers_attach_status=>"0", :iso_attach_status=>"1", :return_value=>"0"}
-    def get_attach_status # rubocop:disable Style/AccessorMethodName
+    def get_attach_status # rubocop:disable Naming/AccessorMethodName
       client.invoke("GetAttachStatus", DEPLOYMENT_SERVICE)
     end
 
@@ -883,7 +886,7 @@ module ASM
     #   {:host_attached_status=>"1", :host_booted_from_iso=>"1",
     #    :ipaddr=>"172.25.3.100", :iso_connection_status=>"1",
     #    :image_name=>"ipxe.iso", :return_value=>"0", :share_name=>"/var/nfs"}
-    def get_network_iso_image_connection_info # rubocop:disable Style/AccessorMethodName
+    def get_network_iso_image_connection_info # rubocop:disable Naming/AccessorMethodName
       client.invoke("GetNetworkISOImageConnectionInfo", DEPLOYMENT_SERVICE)
     end
 
@@ -900,17 +903,17 @@ module ASM
     # @option params [String] :attribute_value The attribute value(s) to set them to.
     # @return [Hash]
     # @raise [ResponseError] if the command fails
-    def set_attributes(params={}) # rubocop:disable Style/AccessorMethodName
+    def set_attributes(params={}) # rubocop:disable Naming/AccessorMethodName
       client.invoke("SetAttributes", BIOS_SERVICE,
                     :params => params,
-                    :required_params => [:target, :attribute_name, :attribute_value],
+                    :required_params => %i[target attribute_name attribute_value],
                     :return_value => "0")
     end
 
     def apply_idrac_attributes(params={})
       client.invoke("ApplyAttributes", APPLY_ATTRIBUTES,
                     :params => params,
-                    :required_params => [:target, :attribute_name, :attribute_value],
+                    :required_params => %i[target attribute_name attribute_value],
                     :return_value => "4096")
     end
 
@@ -936,8 +939,8 @@ module ASM
     def create_targeted_config_job(params={})
       client.invoke("CreateTargetedConfigJob", BIOS_SERVICE,
                     :params => params,
-                    :required_params => [:target],
-                    :optional_params => [:reboot_job_type, :scheduled_start_time, :until_time],
+                    :required_params => %i[target],
+                    :optional_params => %i[reboot_job_type scheduled_start_time until_time],
                     :return_value => "4096")
     end
 
@@ -953,7 +956,7 @@ module ASM
       client.invoke("ChangeBootSourceState",
                     "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_BootConfigSetting",
                     :params => params,
-                    :required_params => [:enabled_state, :source],
+                    :required_params => %i[enabled_state source],
                     :url_params => :instance_id,
                     :return_value => "0")
     end
@@ -1018,8 +1021,8 @@ module ASM
     def import_system_configuration_command(params={})
       client.invoke("ImportSystemConfiguration", LC_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                    :optional_params => [:target, :shutdown_type, :end_host_power_state, :username, :password],
+                    :required_params => %i[ip_address share_name file_name share_type],
+                    :optional_params => %i[target shutdown_type end_host_power_state username password],
                     :return_value => "4096")
     end
 
@@ -1049,8 +1052,8 @@ module ASM
     def export_system_configuration_command(params={})
       client.invoke("ExportSystemConfiguration", LC_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                    :optional_params => [:username, :password, :workgroup, :target, :export_use, :include_in_export],
+                    :required_params => %i[ip_address share_name file_name share_type],
+                    :optional_params => %i[username password workgroup target export_use include_in_export],
                     :return_value => "4096")
     end
 
@@ -1069,8 +1072,8 @@ module ASM
     def export_complete_lc_log(params={})
       client.invoke("ExportCompleteLCLog", LC_SERVICE,
                     :params => params,
-                    :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                    :optional_params => [:username, :password, :workgroup],
+                    :required_params => %i[ip_address share_name file_name share_type],
+                    :optional_params => %i[username password workgroup],
                     :return_value => "4096")
     end
 
@@ -1090,7 +1093,7 @@ module ASM
     def get_config_results(params={})
       client.invoke("GetConfigResults", LC_RECORD_LOG_SERVICE,
                     :params => params,
-                    :optional_params => [:instance_id, :job_id],
+                    :optional_params => %i[instance_id job_id],
                     :return_value => "0")
     end
 
@@ -1138,7 +1141,7 @@ module ASM
     # @option options [Symbol|String] :requested_state :on / "2" or :off / "13"
     # @return [Hash]
     # @raise [ResponseError] if the command fails
-    def set_power_state(params={}) # rubocop:disable Style/AccessorMethodName
+    def set_power_state(params={}) # rubocop:disable Naming/AccessorMethodName
       client.invoke("RequestStateChange", POWER_SERVICE,
                     :params => params,
                     :required_params => :requested_state,
@@ -1188,7 +1191,8 @@ module ASM
         set_power_state(:requested_state => :off)
         (1..30).each do |wait_counter|
           break if power_state == :off
-          logger.debug "Server is not in power-off state. Retry counter %d" % wait_counter if logger
+
+          logger&.debug "Server is not in power-off state. Retry counter %d" % wait_counter
           sleep 10
         end
         logger.warn "Server is still not powered-off. Check the server console" if power_state != :off
@@ -1206,13 +1210,14 @@ module ASM
       max_sleep_secs = 60
       resp = ASM::Util.block_and_retry_until_ready(options[:timeout], RetryException, max_sleep_secs) do
         resp = get_deployment_job(job)
-        unless %w(Success Failed).include?(resp[:job_status])
+        unless %w[Success Failed].include?(resp[:job_status])
           logger.info("%s status on %s: %s" % [job, host, Parser.response_string(resp)])
           raise(RetryException)
         end
         resp
       end
       raise(ResponseError.new("Deployment job %s failed" % job, resp)) unless resp[:job_status] == "Success"
+
       resp
     rescue Timeout::Error
       raise(Error, "Timed out waiting for job %s to complete. Final status: %s" % [job, Parser.response_string(resp)])
@@ -1249,6 +1254,7 @@ module ASM
         resp
       end
       raise(ResponseError.new("LC job %s failed" % job, resp)) unless resp[:job_status] =~ /complete/i
+
       resp
     rescue Timeout::Error
       raise(Error, "Timed out waiting for job %s to complete. Final status: %s" % [job, Parser.response_string(resp)])
@@ -1391,7 +1397,7 @@ module ASM
     # @param (see {#set_attributes})
     # @return [void]
     # @raise [ResponseError] if a command fails or the BIOS configuration job fails
-    def set_bios_attributes(attributes={}) # rubocop:disable Style/AccessorMethodName
+    def set_bios_attributes(attributes={}) # rubocop:disable Naming/AccessorMethodName
       set_attributes(attributes)
       run_bios_config_job(attributes)
     end
@@ -1417,7 +1423,7 @@ module ASM
     # @return [String] the boot source type string, such as UEFI or IPL
     # @raise [ArgumentError] for an invalid boot mode
     def boot_source_type(boot_mode)
-      raise(ArgumentError, "Unsupported boot mode: %s" % boot_mode) unless [:bios, :uefi].include?(boot_mode)
+      raise(ArgumentError, "Unsupported boot mode: %s" % boot_mode) unless %i[bios uefi].include?(boot_mode)
 
       boot_mode == :uefi ? "UEFI" : "IPL"
     end
@@ -1441,7 +1447,7 @@ module ASM
                  :scheduled_start_time => "TIME_NOW",
                  :reboot_job_type => :graceful_with_forced_shutdown}.merge(options)
 
-      raise(ArgumentError, "Invalid boot mode: %s" % options[:boot_mode]) unless [:bios, :uefi].include?(options[:boot_mode])
+      raise(ArgumentError, "Invalid boot mode: %s" % options[:boot_mode]) unless %i[bios uefi].include?(options[:boot_mode])
 
       logger.info("Waiting for LC ready on %s" % host)
       poll_for_lc_ready
@@ -1495,7 +1501,7 @@ module ASM
     #
     # @param state [Symbol] :detach, :attach or :auto_attach
     # @return [void]
-    def set_virtual_media_attach_state(state) # rubocop:disable Style/AccessorMethodName
+    def set_virtual_media_attach_state(state) # rubocop:disable Naming/AccessorMethodName
       state_map = {:detached => "Detached", :attached => "Attached", :auto_attach => "AutoAttach"}
       state_string = Parser.enum_value(nil, state_map, state)
 
@@ -1609,10 +1615,10 @@ module ASM
         raise(Error, "Life cycle controller is busy")
       else
         status = lcstatus(endpoint, logger).to_i
-        if status == 0
+        if status.zero?
           return
         else
-          logger.debug "LC status is busy: status code #{status}. Waiting..." if logger
+          logger&.debug "LC status is busy: status code #{status}. Waiting..."
           sleep sleep_time
           wait_for_lc_ready(endpoint, logger, attempts + 1, max_attempts)
         end
@@ -1667,7 +1673,7 @@ module ASM
       client.invoke("BlinkTarget",
                     RAID_SERVICE,
                     :params => options,
-                    :required_params => [:target],
+                    :required_params => %i[target],
                     :return_value => "0")
     end
 
@@ -1685,7 +1691,7 @@ module ASM
       client.invoke("UnBlinkTarget",
                     RAID_SERVICE,
                     :params => options,
-                    :required_params => [:target],
+                    :required_params => %i[target],
                     :return_value => "0")
     end
 

--- a/lib/asm/wsman/response_error.rb
+++ b/lib/asm/wsman/response_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ASM
   class WsMan
     class Error < StandardError; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, "lib")
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.join(__dir__, "lib")
 
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear

--- a/spec/unit/asm/firmware_spec.rb
+++ b/spec/unit/asm/firmware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/firmware"
 
@@ -15,31 +17,22 @@ describe ASM::Firmware do
          {"rackserver-5xclw12" =>
               {"asm_hostname" => "172.25.5.100",
                "path" => "/var/nfs/firmware/ff808081578bd88601578d525d4e004e/ASMCatalog.xml",
-               "server_firmware" => "Firmware_path"
-              }
-         }
-    }
+               "server_firmware" => "Firmware_path"}}}
   end
 
   let(:resource_hash) do
     [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-      "uri_path" => "rspec-nfs-path"
-     },
+      "uri_path" => "rspec-nfs-path"},
      {"instance_id" => "DCIM:INSTALLED#iDRAC.Embedded.1-1#IDRACinfo",
       "component_id" => "25227",
-      "uri_path" => "rspec-nfs-path"
-     }
-    ]
+      "uri_path" => "rspec-nfs-path"}]
   end
 
   let(:resource_hash2) do
     [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-      "uri_path" => "rspec-nfs-path"
-     },
+      "uri_path" => "rspec-nfs-path"},
      {"instance_id" => "DCIM:INSTALLED#701__NIC.Embedded.1-1-1",
-      "uri_path" => "rspec-nfs-path"
-     }
-    ]
+      "uri_path" => "rspec-nfs-path"}]
   end
 
   let(:device_config) do
@@ -51,21 +44,16 @@ describe ASM::Firmware do
      "arguments" => {"credential_id" => "ff80808157bfd05a0157bfd13392000d"},
      "user" => "rspec-user",
      "enc_password" => nil,
-     "password" => "rspec-password"
-    }
+     "password" => "rspec-password"}
   end
 
   let(:firmware_list) do
     [{"instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-     }
-    ]
+      "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"}]
   end
   let(:firmware_list2) do
     [{"instance_id" => "DCIM:INSTALLED#701__NIC.Embedded.1-1-1",
-      "uri_path" => "nfs://172.25.5.100/FOLDER03287319M/3/Network_Firmware_0MT4K_WN64_7.10.64.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
-     }
-    ]
+      "uri_path" => "nfs://172.25.5.100/FOLDER03287319M/3/Network_Firmware_0MT4K_WN64_7.10.64.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"}]
   end
   let(:status) do
     {
@@ -73,7 +61,7 @@ describe ASM::Firmware do
       :status => "new",
       :firmware => {
         "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
       },
       :start_time => Time.now
     }
@@ -85,7 +73,7 @@ describe ASM::Firmware do
       :status => "Scheduled",
       :firmware => {
         "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
       },
       :start_time => Time.now
     }
@@ -97,7 +85,7 @@ describe ASM::Firmware do
       :status => "Completed",
       :firmware => {
         "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
       },
       :start_time => Time.now
     }
@@ -109,7 +97,7 @@ describe ASM::Firmware do
       :status => "new",
       :firmware => {
         "instance_id" => "DCIM:INSTALLED#701__NIC.Slot.2-2-1",
-        "uri_path"    => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
+        "uri_path" => "nfs://172.25.5.100/FOLDER03355299M/3/Network_Firmware_35RF5_WN64_7.12.19.EXE;mountpoint=/var/nfs/firmware/ff808081578bd88601578d525d4e004e"
       },
       :start_time => Time.now,
       :reboot_required => true,

--- a/spec/unit/asm/ipmi/client_spec.rb
+++ b/spec/unit/asm/ipmi/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "hashie"
 require "asm/ipmi/client"

--- a/spec/unit/asm/ipmi_spec.rb
+++ b/spec/unit/asm/ipmi_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/ipmi"
 

--- a/spec/unit/asm/network_configuration/nic_info_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_info_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/network_configuration"
 
@@ -143,7 +145,7 @@ describe ASM::NetworkConfiguration::NicInfo do
 
     describe "#validate_nic_views" do
       it "should fail if nic views from different nic cards" do
-        fqdds = %w(NIC.Integrated.1-1-1 NIC.Slot.8-1-1)
+        fqdds = %w[NIC.Integrated.1-1-1 NIC.Slot.8-1-1]
         views = fqdds.map { |fqdd| ASM::NetworkConfiguration::NicView.new(fqdd) }
         expect do
           ASM::NetworkConfiguration::NicInfo.validate_nic_views(views)

--- a/spec/unit/asm/network_configuration/nic_port_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_port_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/network_configuration/nic_view"
 require "asm/network_configuration/nic_port"

--- a/spec/unit/asm/network_configuration/nic_type_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/network_configuration"
 

--- a/spec/unit/asm/network_configuration/nic_view_spec.rb
+++ b/spec/unit/asm/network_configuration/nic_view_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/network_configuration/nic_view"
 require "asm/network_configuration/nic_port"

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/network_configuration"
 
@@ -48,9 +50,7 @@ describe ASM::NetworkConfiguration do
 
     it "should not include ipRanges in networkObjects" do
       net_config.get_all_partitions.each do |partition|
-        if partition.static
-          expect(partition.staticNetworkConfiguration.ipRange).to be_nil
-        end
+        expect(partition.staticNetworkConfiguration.ipRange).to be_nil if partition.static
       end
     end
 
@@ -721,13 +721,8 @@ describe ASM::NetworkConfiguration do
                      "NIC.Integrated.1-4-1" => "00:0A:F9:06:88:56"}
 
       nic_views = build_nic_views(fqdd_to_mac) do |nic_view|
-        if nic_view["FQDD"] =~ /Integrated/
-          nic_view["VendorName"] = "Broadcom"
-          nic_view["ProductName"] = "57800"
-        else
-          nic_view["VendorName"] = "Broadcom"
-          nic_view["ProductName"] = "57810"
-        end
+        nic_view["VendorName"] = "Broadcom"
+        nic_view["ProductName"] = nic_view["FQDD"] =~ /Integrated/ ? "57800" : "57810"
       end
       ASM::WsMan.stubs(:get_nic_view).returns(nic_views)
       net_config.add_nics!(Hashie::Mash.new(:host => "127.0.0.1"))

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "asm/util"
 require "asm/errors"
 require "spec_helper"
@@ -65,26 +67,28 @@ describe ASM::Util do
   end
 
   it "should parse esxcli thumbprint and output" do
-    esxcli_thumbprint_msg = <<-eos
-Connect to 100.1.1.100 failed. Server SHA-1 thumbprint: 28:C6:8D:54:1B:08:A1:08:7A:0B:50:6D:B7:73:06:96:71:A1:6D:03 (not trusted).
-    eos
+    esxcli_thumbprint_msg = <<~OUTPUT
+      Connect to 100.1.1.100 failed. Server SHA-1 thumbprint: 28:C6:8D:54:1B:08:A1:08:7A:0B:50:6D:B7:73:06:96:71:A1:6D:03 (not trusted).
+    OUTPUT
+
     err_result = {
       "exit_status" => 1,
       "stdout" => esxcli_thumbprint_msg
     }
 
-    stdout = <<-eos
-Name                    Virtual Switch  Active Clients  VLAN ID
-----------------------  --------------  --------------  -------
-ISCSI0                  vSwitch3                     1       16
-ISCSI1                  vSwitch3                     1       16
-Management Network      vSwitch0                     1        0
-Management Network (1)  vSwitch0                     1       28
-VM Network              vSwitch0                     1        0
-Workload Network        vSwitch2                     0       20
-vMotion                 vSwitch1                     1       23
+    stdout = <<~OUTPUT
+      Name                    Virtual Switch  Active Clients  VLAN ID
+      ----------------------  --------------  --------------  -------
+      ISCSI0                  vSwitch3                     1       16
+      ISCSI1                  vSwitch3                     1       16
+      Management Network      vSwitch0                     1        0
+      Management Network (1)  vSwitch0                     1       28
+      VM Network              vSwitch0                     1        0
+      Workload Network        vSwitch2                     0       20
+      vMotion                 vSwitch1                     1       23
 
-    eos
+    OUTPUT
+
     result = {
       "exit_status" => 0,
       "stdout" => stdout
@@ -100,18 +104,19 @@ vMotion                 vSwitch1                     1       23
   end
 
   it "should parse esxcli output and use provided thumbprint" do
-    stdout = <<-eos
-Name                    Virtual Switch  Active Clients  VLAN ID
-----------------------  --------------  --------------  -------
-ISCSI0                  vSwitch3                     1       16
-ISCSI1                  vSwitch3                     1       16
-Management Network      vSwitch0                     1        0
-Management Network (1)  vSwitch0                     1       28
-VM Network              vSwitch0                     1        0
-Workload Network        vSwitch2                     0       20
-vMotion                 vSwitch1                     1       23
+    stdout = <<~OUTPUT
+      Name                    Virtual Switch  Active Clients  VLAN ID
+      ----------------------  --------------  --------------  -------
+      ISCSI0                  vSwitch3                     1       16
+      ISCSI1                  vSwitch3                     1       16
+      Management Network      vSwitch0                     1        0
+      Management Network (1)  vSwitch0                     1       28
+      VM Network              vSwitch0                     1        0
+      Workload Network        vSwitch2                     0       20
+      vMotion                 vSwitch1                     1       23
 
-    eos
+    OUTPUT
+
     result = {
       "exit_status" => 0,
       "stdout" => stdout
@@ -139,7 +144,7 @@ vMotion                 vSwitch1                     1       23
     end
   end
 
-  describe '#hostname_to_certname' do
+  describe "#hostname_to_certname" do
     it "should generate a certname and not clobber the original hostname" do
       certname = "CrAzY_NaMe1234"
       expect(ASM::Util.hostname_to_certname(certname)).to eq("agent-crazyname1234")
@@ -177,11 +182,11 @@ vMotion                 vSwitch1                     1       23
 
       ASM::Util.expects(:`)
                .with("ip route get 192.168.253.100")
-               .returns(<<EOF
-192.168.253.100 dev ens192 src 192.168.253.1
-    cache
+               .returns(<<~OUTPUT
+                 192.168.253.100 dev ens192 src 192.168.253.1
+                     cache
 
-EOF
+               OUTPUT
                        )
 
       expect(ASM::Util.get_preferred_ip("host-foo", logger)).to eq("192.168.253.1")
@@ -196,12 +201,12 @@ EOF
       ASM::Util.expects(:`)
                .at_least_once
                .with("ip route")
-               .returns(<<EOF
-default via 100.68.107.190 dev ens160 proto static metric 100
-100.68.107.128/26 dev ens160 proto kernel scope link src 100.68.107.160 metric 100
-192.168.253.0/24 dev ens192 proto kernel scope link src 192.168.253.1 metric 100
+               .returns(<<~OUTPUT
+                 default via 100.68.107.190 dev ens160 proto static metric 100
+                 100.68.107.128/26 dev ens160 proto kernel scope link src 100.68.107.160 metric 100
+                 192.168.253.0/24 dev ens192 proto kernel scope link src 192.168.253.1 metric 100
 
-EOF
+               OUTPUT
                        )
 
       expect {ASM::Util.get_preferred_ip("192.168.253.100", logger)}.to raise_error("Failed to find preferred route to 192.168.253.100 after 10 tries")

--- a/spec/unit/asm/wsman/client_spec.rb
+++ b/spec/unit/asm/wsman/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "hashie"
 require "asm/wsman/client"

--- a/spec/unit/asm/wsman/parser_spec.rb
+++ b/spec/unit/asm/wsman/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/wsman/parser"
 

--- a/spec/unit/asm/wsman/response_errror_spec.rb
+++ b/spec/unit/asm/wsman/response_errror_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/wsman/response_error"
 

--- a/spec/unit/asm/wsman_spec.rb
+++ b/spec/unit/asm/wsman_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "asm/wsman"
 
@@ -192,7 +194,7 @@ describe ASM::WsMan do
     it "should invoke SetAttributes" do
       client.expects(:invoke).with("SetAttributes", ASM::WsMan::BIOS_SERVICE,
                                    :params => {},
-                                   :required_params => [:target, :attribute_name, :attribute_value],
+                                   :required_params => %i[target attribute_name attribute_value],
                                    :return_value => "0")
       wsman.set_attributes
     end
@@ -203,7 +205,7 @@ describe ASM::WsMan do
       client.expects(:invoke).with("ChangeBootSourceState",
                                    "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_BootConfigSetting",
                                    :params => {},
-                                   :required_params => [:enabled_state, :source],
+                                   :required_params => %i[enabled_state source],
                                    :url_params => :instance_id,
                                    :return_value => "0")
       wsman.change_boot_source_state
@@ -225,8 +227,8 @@ describe ASM::WsMan do
     it "should invoke ImportSystemConfiguration" do
       client.expects(:invoke).with("ImportSystemConfiguration", ASM::WsMan::LC_SERVICE,
                                    :params => {},
-                                   :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                                   :optional_params => [:target, :shutdown_type, :end_host_power_state, :username, :password],
+                                   :required_params => %i[ip_address share_name file_name share_type],
+                                   :optional_params => %i[target shutdown_type end_host_power_state username password],
                                    :return_value => "4096")
       wsman.import_system_configuration_command
     end
@@ -236,8 +238,8 @@ describe ASM::WsMan do
     it "should invoke ExportSystemConfiguration" do
       client.expects(:invoke).with("ExportSystemConfiguration", ASM::WsMan::LC_SERVICE,
                                    :params => {},
-                                   :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                                   :optional_params => [:username, :password, :workgroup, :target, :export_use, :include_in_export],
+                                   :required_params => %i[ip_address share_name file_name share_type],
+                                   :optional_params => %i[username password workgroup target export_use include_in_export],
                                    :return_value => "4096")
       wsman.export_system_configuration_command
     end
@@ -247,8 +249,8 @@ describe ASM::WsMan do
     it "should invoke ExportCompleteLCLog" do
       client.expects(:invoke).with("ExportCompleteLCLog", ASM::WsMan::LC_SERVICE,
                                    :params => {},
-                                   :required_params => [:ip_address, :share_name, :file_name, :share_type],
-                                   :optional_params => [:username, :password, :workgroup],
+                                   :required_params => %i[ip_address share_name file_name share_type],
+                                   :optional_params => %i[username password workgroup],
                                    :return_value => "4096")
       wsman.export_complete_lc_log
     end
@@ -258,7 +260,7 @@ describe ASM::WsMan do
     it "should invoke GetConfigResults" do
       client.expects(:invoke).with("GetConfigResults", ASM::WsMan::LC_RECORD_LOG_SERVICE,
                                    :params => {},
-                                   :optional_params => [:instance_id, :job_id],
+                                   :optional_params => %i[instance_id job_id],
                                    :return_value => "0").returns("rspec-result")
       expect(wsman.get_config_results).to eq("rspec-result")
     end
@@ -268,7 +270,7 @@ describe ASM::WsMan do
     it "should invoke CreateRebootJob" do
       client.expects(:invoke).with("CreateRebootJob", ASM::WsMan::SOFTWARE_INSTALLATION_SERVICE,
                                    :params => {},
-                                   :optional_params => [:reboot_start_time, :reboot_job_type],
+                                   :optional_params => %i[reboot_start_time reboot_job_type],
                                    :return_value => "4096").returns("rspec-result")
       expect(wsman.create_reboot_job).to eq("rspec-result")
     end
@@ -278,7 +280,7 @@ describe ASM::WsMan do
     it "should invoke SetupJobQueue" do
       client.expects(:invoke).with("SetupJobQueue", ASM::WsMan::JOB_SERVICE,
                                    :params => {},
-                                   :optional_params => [:job_array, :start_time_interval, :until_time],
+                                   :optional_params => %i[job_array start_time_interval until_time],
                                    :return_value => "0").returns("rspec-result")
       expect(wsman.setup_job_queue).to eq("rspec-result")
     end
@@ -297,7 +299,7 @@ describe ASM::WsMan do
     it "should invoke DeleteJobQueue" do
       client.expects(:invoke).with("DeleteJobQueue", ASM::WsMan::JOB_SERVICE,
                                    :params => {},
-                                   :optional_params => [:job_id],
+                                   :optional_params => %i[job_id],
                                    :return_value => "0").returns("rspec-result")
       expect(wsman.delete_job_queue).to eq("rspec-result")
     end
@@ -362,8 +364,8 @@ describe ASM::WsMan do
       client.expects(:invoke)
             .with("BootToNetworkISO", ASM::WsMan::DEPLOYMENT_SERVICE,
                   :params => {},
-                  :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                  :optional_params => [:workgroup, :user_name, :password, :hash_type, :hash_value, :auto_connect],
+                  :required_params => %i[ip_address share_name share_type image_name],
+                  :optional_params => %i[workgroup user_name password hash_type hash_value auto_connect],
                   :return_value => "4096")
             .returns("rspec-result")
       expect(wsman.boot_to_network_iso_command).to eq("rspec-result")
@@ -375,8 +377,8 @@ describe ASM::WsMan do
       client.expects(:invoke)
             .with("ConnectNetworkISOImage", ASM::WsMan::DEPLOYMENT_SERVICE,
                   :params => {},
-                  :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                  :optional_params => [:workgroup, :user_name, :password, :hash_type, :hash_value, :auto_connect],
+                  :required_params => %i[ip_address share_name share_type image_name],
+                  :optional_params => %i[workgroup user_name password hash_type hash_value auto_connect],
                   :return_value => "4096")
             .returns("rspec-result")
       wsman.expects(:parse_iso_uri).with("nfs://localhost/ipxe.iso").returns({})
@@ -389,8 +391,8 @@ describe ASM::WsMan do
       client.expects(:invoke)
             .with("ConnectRFSISOImage", ASM::WsMan::DEPLOYMENT_SERVICE,
                   :params => {},
-                  :required_params => [:ip_address, :share_name, :share_type, :image_name],
-                  :optional_params => [:workgroup, :username, :password, :hash_type, :hash_value, :auto_connect],
+                  :required_params => %i[ip_address share_name share_type image_name],
+                  :optional_params => %i[workgroup username password hash_type hash_value auto_connect],
                   :return_value => "4096")
             .returns("rspec-result")
       wsman.expects(:parse_iso_uri).with("nfs://localhost/ipxe.iso").returns({})
@@ -657,7 +659,7 @@ describe ASM::WsMan do
       wsman.expects(:bios_enumerations).returns([{:fqdd => "BiosFqdd", :attribute_name => "BootMode", :current_value => "Uefi"}])
       wsman.expects(:set_bios_attributes).with(:target => "BiosFqdd", :attribute_name => "BootMode", :attribute_value => "Bios")
       wsman.expects(:find_boot_device).with(:virtual_cd).returns(nil)
-      wsman.expects(:boot_source_settings).returns(%w(Hdd VirtualCd Nic).map { |e| {:element_name => e}})
+      wsman.expects(:boot_source_settings).returns(%w[Hdd VirtualCd Nic].map { |e| {:element_name => e}})
       message = "Could not find virtual_cd boot device in current list: Hdd, VirtualCd, Nic"
       expect {wsman.set_boot_order(:virtual_cd, opts)}.to raise_error(message)
     end
@@ -890,7 +892,7 @@ describe ASM::WsMan do
       client.expects(:invoke).with("BlinkTarget",
                                    ASM::WsMan::RAID_SERVICE,
                                    :params => {:target => "Disk.Bay.1:Enclosure.Internal.0-1:NonRAID.Integrated.1-1"},
-                                   :required_params => [:target],
+                                   :required_params => %i[target],
                                    :return_value => "0")
       wsman.blink_target(:target => "Disk.Bay.1:Enclosure.Internal.0-1:NonRAID.Integrated.1-1")
     end
@@ -901,7 +903,7 @@ describe ASM::WsMan do
       client.expects(:invoke).with("UnBlinkTarget",
                                    ASM::WsMan::RAID_SERVICE,
                                    :params => {:target => "Disk.Bay.1:Enclosure.Internal.0-1:NonRAID.Integrated.1-1"},
-                                   :required_params => [:target],
+                                   :required_params => %i[target],
                                    :return_value => "0")
       wsman.unblink_target(:target => "Disk.Bay.1:Enclosure.Internal.0-1:NonRAID.Integrated.1-1")
     end

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Run rubocop style and lint checks"
 task :rubocop do
   sh("bundle exec rubocop -f progress -f offenses")


### PR DESCRIPTION
The versions of nokogiri and rubocop used had low to moderate
security vulnerabilities reported. Nokogiri was previously pinned to a
lower version because of a memory leak with jruby and the 1.8.x
versions. That issue appears to be resolved in the latest
versions. Rubocop was pinned just to avoid failing new checks that
constantly get added. This change updates to the latest versions to
resolve the security warnings.

Most of the changes here are to conform to new Rubocop checks and
update the base ruby version to 2.3 Support for JRuby 1.7 was removed.