### PR TITLE
VXFM-5171 Inventory fails as host key checking seems to still occur on Ansible inventories.

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -528,6 +528,22 @@ module ASM
       end
     end
 
+    # Remove host entries in /home/razor/.ssh/known hosts file which can cause ansible run to fail
+    #
+    # @param ips [Array] List of host IPs to search and remove for in known_hosts file
+    # @return [List<String>] List of IPs that could not be removed
+    def self.remove_host_entries(ips, hosts_file=nil)
+      failed_ips = []
+      ips.each do |ip|
+        args = %w[ssh-keygen -R]
+        args.push(ip)
+        result = run_command(*args)
+        failed_ips.push(ip) unless result["exit_status"].zero?
+      end
+
+      failed_ips
+    end
+
     # ASM services send single-element arrays as just the single element (hash).
     # This method ensures we get a single-element array in that case
     def self.asm_json_array(elem)

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -363,6 +363,24 @@ describe ASM::Util do
     end
   end
 
+  describe "#remove_host_entries" do
+    it "should remove ips from host file if present" do
+      args = %w[ssh-keygen -R 100.68.106.193]
+      ASM::Util.expects(:run_command).with(*args).returns("exit_status" => 0)
+      args = %w[ssh-keygen -R 100.68.106.196]
+      ASM::Util.expects(:run_command).with(*args).returns("exit_status" => 0)
+      expect(ASM::Util.remove_host_entries(["100.68.106.193", "100.68.106.196"])).to eq([])
+    end
+
+    it "should return ips that failed to remove" do
+      args = %w[ssh-keygen -R 100.68.106.193]
+      ASM::Util.expects(:run_command).with(*args).returns("exit_status" => 1)
+      args = %w[ssh-keygen -R 100.68.106.196]
+      ASM::Util.expects(:run_command).with(*args).returns("exit_status" => 0)
+      expect(ASM::Util.remove_host_entries(["100.68.106.193", "100.68.106.196"])).to eq(["100.68.106.193"])
+    end
+  end
+
   describe "run_ansible_playbook_with_inventory" do
     before(:each) do
       @play = "/tmp/testplay.yaml"


### PR DESCRIPTION
Provide method to remove host file entry which can be called before
ansible run.