### PR TITLE
VXFM-7884 PXE Distributed port-group is not created after VDS refactoring changes

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -356,6 +356,8 @@ module ASM
     # @example
     #   { [ :TeamInfo => { :networks => [...], :mac_addresses => [ ... ] ] }
     def teams(opt={})
+      @teams = nil if opt[:refresh_info]
+
       @teams ||= begin
         raise("NIC MAC Address information needs to updated to network configuration. Invoke nc.add_nics!") unless @network_config_add_nic
 


### PR DESCRIPTION
NIC Team information is getting cached. During VDS and Distributed PG configuration PXE network information was missing from the NIC team response, Now we have included a option to refresh the information as when required.