### PR TITLE
 VXFM-8972 High chance linux CO nodes will fail first time and require retry

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -338,7 +338,7 @@ module ASM
       Net::SSH.start(server,
                      username,
                      :password => password,
-                     :verify_host_key => Net::SSH::Verifiers::Null.new,
+                     :verify_host_key => false,
                      :global_known_hosts_file => "/dev/null") do |ssh|
         cmd = ([command] + [arguments]).join(" ").strip
 

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -515,8 +515,6 @@ describe ASM::Util do
 
   describe "#execute_script_via_ssh" do
     it "it should run ssh command" do
-      Net::SSH::Verifiers::Null = mock("Null")
-      Net::SSH::Verifiers::Null.expects(:new).returns(true)
       session = mock("session")
       channel = mock("channel")
       channel.expects(:exec).yields("test", true)
@@ -526,7 +524,7 @@ describe ASM::Util do
       session.expects(:open_channel).at_least_once.yields(channel)
       session.expects(:loop)
       Net::SSH.expects(:start)
-              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => true, :global_known_hosts_file => "/dev/null")
+              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => false, :global_known_hosts_file => "/dev/null")
               .yields(session)
       result = ASM::Util.execute_script_via_ssh("155.68.106.198", "root", "P@ssw0rd", "ls", "-lrt")
       expect(result).to eq(:exit_code => -1, :stderr => "", :stdout => "test")


### PR DESCRIPTION
Constant Net::SSH::Verifiers::Null is available in the latest Net::SSH version leading to the falure. Replaced this with false which is the valid equivalent of the constant in the current release.