### PR TITLE
VXFM-9100 Automated iDrac reset was failing due to Net::SSH changes

### DIFF
--- a/lib/asm/transport/racadm.rb
+++ b/lib/asm/transport/racadm.rb
@@ -24,7 +24,7 @@ module ASM
         Net::SSH.start(@endpoint[:host],
                        @endpoint[:user],
                        :password => @endpoint[:password],
-                       :paranoid => Net::SSH::Verifiers::Null.new,
+                       :verify_host_key => false,
                        :global_known_hosts_file => "/dev/null") do |ssh|
           ssh.exec!("racadm racreset soft") do |_, stream, data|
             logger.debug(data)

--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -338,7 +338,7 @@ module ASM
       Net::SSH.start(server,
                      username,
                      :password => password,
-                     :verify_host_key => Net::SSH::Verifiers::Null.new,
+                     :verify_host_key => false,
                      :global_known_hosts_file => "/dev/null") do |ssh|
         cmd = ([command] + [arguments]).join(" ").strip
 

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -21,6 +21,7 @@ module ASM
     POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem&SystemName=systemmc&CreationClassName=DCIM_CSPowerManagementService&Name=pwrmgtsvc:1"
     SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate"
     IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState"
+    GENERAL_IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration"
     APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_iDRACCardService&SystemName=DCIM:ComputerSystem&Name=DCIM:iDRACCardService"
     SYSTEM_MANAGEMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SystemManagementService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_SystemManagementService&SystemName=srv:system&Name=DCIM:SystemManagementService"
     RAID_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_RAIDService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_RAIDService&SystemName=DCIM:ComputerSystem&Name=DCIM:RAIDService"
@@ -337,6 +338,10 @@ module ASM
     #     ]
     def idrac_card_enumeration
       client.enumerate(IDRAC_CARD_ENUMERATION)
+    end
+
+    def ism_state
+      client.get(GENERAL_IDRAC_CARD_ENUMERATION, "iDRAC.Embedded.1#ServiceModule.1#ServiceModuleState")
     end
 
     # Get server power state

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -515,8 +515,6 @@ describe ASM::Util do
 
   describe "#execute_script_via_ssh" do
     it "it should run ssh command" do
-      Net::SSH::Verifiers::Null = mock("Null")
-      Net::SSH::Verifiers::Null.expects(:new).returns(true)
       session = mock("session")
       channel = mock("channel")
       channel.expects(:exec).yields("test", true)
@@ -526,7 +524,7 @@ describe ASM::Util do
       session.expects(:open_channel).at_least_once.yields(channel)
       session.expects(:loop)
       Net::SSH.expects(:start)
-              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => true, :global_known_hosts_file => "/dev/null")
+              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => false, :global_known_hosts_file => "/dev/null")
               .yields(session)
       result = ASM::Util.execute_script_via_ssh("155.68.106.198", "root", "P@ssw0rd", "ls", "-lrt")
       expect(result).to eq(:exit_code => -1, :stderr => "", :stdout => "test")


### PR DESCRIPTION
`Net::SSH::Verifiers::Null` was removed. It looks like
`:verify_host_key => :never` is the more correct way to disable host
key verification but for Dacite release sticking with
`:verify_host_key => false` which is already in use in existing code.