### PR TITLE
VXFM-9100 Add wait for LC ready before clearing job queue

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -338,7 +338,7 @@ module ASM
       Net::SSH.start(server,
                      username,
                      :password => password,
-                     :verify_host_key => Net::SSH::Verifiers::Null.new,
+                     :verify_host_key => false,
                      :global_known_hosts_file => "/dev/null") do |ssh|
         cmd = ([command] + [arguments]).join(" ").strip
 

--- a/lib/asm/wsman.rb
+++ b/lib/asm/wsman.rb
@@ -21,6 +21,7 @@ module ASM
     POWER_STATE_CHANGE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_CSPowerManagementService?SystemCreationClassName=DCIM_SPComputerSystem&SystemName=systemmc&CreationClassName=DCIM_CSPowerManagementService&Name=pwrmgtsvc:1"
     SOFTWARE_INSTALLATION_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate"
     IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration?InstanceID=iDRAC.Embedded.1#VirtualConsole.1#AttachState"
+    GENERAL_IDRAC_CARD_ENUMERATION = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/DCIM_iDRACCardEnumeration"
     APPLY_ATTRIBUTES = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_iDRACCardService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_iDRACCardService&SystemName=DCIM:ComputerSystem&Name=DCIM:iDRACCardService"
     SYSTEM_MANAGEMENT_SERVICE = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SystemManagementService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_SystemManagementService&SystemName=srv:system&Name=DCIM:SystemManagementService"
     RAID_SERVICE = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_RAIDService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_RAIDService&SystemName=DCIM:ComputerSystem&Name=DCIM:RAIDService"
@@ -337,6 +338,10 @@ module ASM
     #     ]
     def idrac_card_enumeration
       client.enumerate(IDRAC_CARD_ENUMERATION)
+    end
+
+    def ism_state
+      client.get(GENERAL_IDRAC_CARD_ENUMERATION, "iDRAC.Embedded.1#ServiceModule.1#ServiceModuleState")
     end
 
     # Get server power state

--- a/spec/unit/asm/firmware_spec.rb
+++ b/spec/unit/asm/firmware_spec.rb
@@ -143,7 +143,7 @@ describe ASM::Firmware do
 
     it "should clear the job queue successfully" do
       wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").returns(response)
-      wsman.expects(:poll_for_lc_ready)
+      wsman.expects(:poll_for_lc_ready).twice
       firmware_obj.expects(:job_queue_clear?).returns(true)
       firmware_obj.clear_job_queue_retry(wsman)
     end
@@ -167,6 +167,7 @@ describe ASM::Firmware do
       firmware_obj.stubs(:sleep).returns(nil).at_least_once
       wsman.expects(:client).returns(stub(:endpoint => endpoint)).times(2)
       ASM::Transport::Racadm.expects(:new).with(endpoint, logger).returns(mock_transport).times(2)
+      wsman.expects(:poll_for_lc_ready).at_least_once
       wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL").returns(response2)
       wsman.expects(:delete_job_queue).with(:job_id => "JID_CLEARALL_FORCE").twice.returns(response2).times(2)
       expect do

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -515,8 +515,6 @@ describe ASM::Util do
 
   describe "#execute_script_via_ssh" do
     it "it should run ssh command" do
-      Net::SSH::Verifiers::Null = mock("Null")
-      Net::SSH::Verifiers::Null.expects(:new).returns(true)
       session = mock("session")
       channel = mock("channel")
       channel.expects(:exec).yields("test", true)
@@ -526,7 +524,7 @@ describe ASM::Util do
       session.expects(:open_channel).at_least_once.yields(channel)
       session.expects(:loop)
       Net::SSH.expects(:start)
-              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => true, :global_known_hosts_file => "/dev/null")
+              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => false, :global_known_hosts_file => "/dev/null")
               .yields(session)
       result = ASM::Util.execute_script_via_ssh("155.68.106.198", "root", "P@ssw0rd", "ls", "-lrt")
       expect(result).to eq(:exit_code => -1, :stderr => "", :stdout => "test")


### PR DESCRIPTION
Seeing cases where force clearing the job queue failed which appear to
be caused by issuing the command when LC is not ready.