### PR TITLE
VXFM-9282 ESXCLI VMNIC parsing failing

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -210,27 +210,40 @@ module ASM
       header_line = lines.shift
       headers = header_line.split(/\s\s+/).map(&:strip)
 
-      _seps = lines.shift
+      seps = lines.shift
 
-      columns = []
-      start_pos = 0
-      headers[1...headers.length].each do |header|
-        end_pos = header_line.index(header)
-        columns << start_pos
-        start_pos = end_pos
+      columns = [0]
+      index = 1
+
+      loop do
+        index = seps.index(" ", index)
+        break unless index
+
+        columns << index + 2
+        index += 2
       end
 
-      columns << start_pos
+      if columns.size != headers.size
+        columns = []
+        start_pos = 0
+        headers[1...headers.length].each do |header|
+          end_pos = header_line.index(header)
+          columns << start_pos
+          start_pos = end_pos
+        end
+
+        columns << start_pos
+      end
 
       ret = []
       lines.each do |line|
         next unless line.length >= columns.last
 
         record = {}
-        columns.each_with_index do |column, index|
-          end_pos = index < columns.size - 1 ? columns[index + 1] : line.length
+        columns.each_with_index do |column, l_index|
+          end_pos = l_index < columns.size - 1 ? columns[l_index + 1] : line.length
           value = line[column...end_pos].strip
-          record[headers[index]] = value
+          record[headers[l_index]] = value
         end
         ret.push(record)
       end

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -592,11 +592,11 @@ describe ASM::Util do
       expect(records.length).to eq(9)
       expect(records[0]).to eq("Name" => "vmnic0", "PCI Device" => "0000:18:00.0", "Driver" => "i40en",
                                "Admin Status" => "Up", "Link Status" => "Up", "Speed" => "10000", "Duplex" => "Full",
-                               "MAC Address" => "24:6e:96:5c:d8:1c  1", "MTU" => "500",
+                               "MAC Address" => "24:6e:96:5c:d8:1c", "MTU" => "1500",
                                "Description" => "Intel(R) Ethernet Controller X710 for 10GbE SFP+")
       expect(records[8]).to eq("Name" => "vusb0", "PCI Device" => "Pseudo", "Driver" => "cdce", "Admin Status" => "Up",
-                               "Link Status" => "Up", "Speed" => "100", "Duplex" => "Full", "MAC Address" => "50:9a:4c:aa:24:c9  1",
-                               "MTU" => "500", "Description" => "DellTM iDRAC Virtual NIC USB Device")
+                               "Link Status" => "Up", "Speed" => "100", "Duplex" => "Full", "MAC Address" => "50:9a:4c:aa:24:c9",
+                               "MTU" => "1500", "Description" => "DellTM iDRAC Virtual NIC USB Device")
     end
   end
 end


### PR DESCRIPTION
Due to recent refactoring of dell-asm-util for ESXCLI parsing, few columns were not getting parsed correctly leading to the failure in identifying the VMNICS. Updated the paring logic to ensure we collect all the headers and respective information