### PR TITLE
VXFM-10479 - Allow deployments to go through if no PXE vlan specified…

### DIFF
--- a/lib/asm/network_configuration.rb
+++ b/lib/asm/network_configuration.rb
@@ -166,6 +166,10 @@ module ASM
     # with them such as iSCSI or public/private lan.
     def get_network(network_type)
       ret = get_networks(network_type)
+      # If we get an empty network, send back as nil
+      # We don't want to raise an error for brownfield where networks can be missing
+      return nil if ret.empty?
+
       if ret.size == 1
         ret[0]
       else

--- a/spec/unit/asm/network_configuration_spec.rb
+++ b/spec/unit/asm/network_configuration_spec.rb
@@ -209,6 +209,11 @@ describe ASM::NetworkConfiguration do
       end.to raise_error('There should be only one STORAGE_ISCSI_SAN network but found 2: ["iSCSI", "iSCSI"]')
     end
 
+    it "should return nil if no networks found" do
+      net_config.stubs(:get_networks).with("PXE").returns([])
+      expect(net_config.get_network("PXE")).to eq(nil)
+    end
+
     it "should find storage networks with correct mac addresses" do
       fqdd_to_mac = {"NIC.Integrated.1-1-1" => "00:0E:1E:0D:8C:30",
                      "NIC.Integrated.1-1-2" => "00:0E:1E:0D:8C:32",


### PR DESCRIPTION
…, needed for brownfield to enter lifecycle mode