### PR TITLE
VXFM-9700 Record exception in the thread

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -17,15 +17,18 @@ require "shellwords"
 module ASM
   # Use this instead of Thread.new, or your exceptions will disappear into the ether...
   def self.execute_async(logger, &block)
-    Thread.new do
+    thread = Thread.new do
       begin
         yield
       # NOTE: really do want to rescue Exception and not StandardError here,
       # otherwise these failures will not be logged anywhere.
       rescue Exception => e # rubocop:disable Lint/RescueException
         logger.error(e.message + "\n" + e.backtrace.join("\n"))
+        thread[:exception] = e
       end
     end
+
+    thread
   end
 
   # Various utility methods

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -16,6 +16,20 @@ describe ASM::Util do
     @tmpfile.unlink
   end
 
+  describe "execute_async" do
+    it "should execute async operation" do
+      logger = mock("rspec")
+
+      ASM.execute_async(logger) do
+        def test_method
+          raise("Error")
+        end
+
+        test_method
+      end
+    end
+  end
+
   describe "retries and timeouts" do
     it "should reraise unhandled exceptions" do
       expect do


### PR DESCRIPTION
If exeception is encounted in threaded operation then need to include the information in the returned information so that calling method can take corrective action