### PR TITLE
VXFM-9677 Fixed ioctl error for ssh authentication issue

### DIFF
--- a/lib/asm/util.rb
+++ b/lib/asm/util.rb
@@ -382,6 +382,7 @@ module ASM
                      username,
                      :password => password,
                      :verify_host_key => false,
+                     :non_interactive => true,
                      :global_known_hosts_file => "/dev/null") do |ssh|
         cmd = ([command] + [arguments]).join(" ").strip
 

--- a/spec/unit/asm/util_spec.rb
+++ b/spec/unit/asm/util_spec.rb
@@ -538,7 +538,7 @@ describe ASM::Util do
       session.expects(:open_channel).at_least_once.yields(channel)
       session.expects(:loop)
       Net::SSH.expects(:start)
-              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => false, :global_known_hosts_file => "/dev/null")
+              .with("155.68.106.198", "root", :password => "P@ssw0rd", :verify_host_key => false, :non_interactive => true, :global_known_hosts_file => "/dev/null")
               .yields(session)
       result = ASM::Util.execute_script_via_ssh("155.68.106.198", "root", "P@ssw0rd", "ls", "-lrt")
       expect(result).to eq(:exit_code => -1, :stderr => "", :stdout => "test")


### PR DESCRIPTION
Currently, ssh session will prompt for a correct password if VXFM uses incorrect password during session initiation and eventually raises ioctl error.

This PR adds non-interactive option making session non-interactive and fails with authentication error when an incorrect password is used.